### PR TITLE
Actor identity, identity labels, and a receipt contract for state-changing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ pal cli status        # check your setup
 | `pal cli migrate` | Run pending data migrations (non-destructive) |
 | `pal cli analyze [--actionable]` | Learning analysis: rating trends, failure patterns, graduation candidates |
 | `pal cli usage` | Summarize token usage and estimated cost |
+| `pal cli actor [label <name>]` | Show or rename the actor — who caused a record. Travels with an export, so a shared memory can tell two people apart |
+| `pal cli machine [label <name>]` | Show or rename this install — where a record was written. Never leaves the machine |
 | `pal cli knowledge` | Query & manage the knowledge store (search, graph, stats, hubs, find, show, add, ls, ingest) |
 | `pal cli skill link <name>` | Link a personal `~/.pal/skills/<name>/` into every installed agent so it is discoverable |
 | `pal cli skill doctor <name>` | Evaluate a skill against the authoring best practices (folder/file-name match, name, description, body length, point-of-view, reference depth) |

--- a/klint.rules.ts
+++ b/klint.rules.ts
@@ -76,9 +76,51 @@ const noAgentImportInCore = defineRule({
   },
 });
 
+/**
+ * A tool that writes to disk must not report the write only through emit.ok().
+ *
+ * emit.ok() is TTY-gated (see src/tools/lib/emit.ts), so a tool that confirms a
+ * write through it says nothing at all when an agent runs it over a pipe. The
+ * caller then re-reads the file to learn what happened, which costs far more
+ * context than the receipt would have. emit.receipt() and emit.data() are
+ * ungated; either satisfies this rule.
+ *
+ * Scoped to files that use the emit convention at all — a tool printing its own
+ * ungated output is already telling the caller what landed.
+ */
+const noSilentWrite = defineRule({
+  check({ files, root }, violations) {
+    const toolDirs = [resolve(root, "src/tools"), resolve(root, "assets/skills")];
+    const writeCall = /\b(writeFileSync|appendFileSync)\s*\(/;
+
+    const scope = files.filter(
+      (f) =>
+        toolDirs.some((dir) => f.startsWith(dir)) &&
+        f.endsWith(".ts") &&
+        !f.endsWith("emit.ts")
+    );
+
+    for (const file of scope) {
+      const content = readFileSync(file, "utf-8");
+      if (!writeCall.test(content)) continue;
+      if (!/emit\.ok\s*\(/.test(content)) continue;
+      if (/emit\.(receipt|data)\s*\(/.test(content)) continue;
+
+      const lines = content.split("\n");
+      violations.push({
+        file: relative(root, file),
+        line: lines.findIndex((l) => /emit\.ok\s*\(/.test(l)) + 1,
+        message:
+          "Tool writes to disk but confirms it only via emit.ok(), which is TTY-gated and silent over a pipe — a caller cannot tell what landed or where. Use emit.receipt(path, {...}).",
+      });
+    }
+  },
+});
+
 /** @lintignore — loaded via dynamic import by klint/cli.ts */
 export default {
   "no-console-in-hook-lib": noConsoleInHookLib,
   "no-raw-anthropic-fetch": noRawAnthropicFetch,
   "no-agent-import-in-core": noAgentImportInCore,
+  "no-silent-write": noSilentWrite,
 };

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,104 @@
+/**
+ * pal cli actor / pal cli machine — read and rename the two identities PAL keeps.
+ *
+ *   pal cli actor                 Show this actor's label and id
+ *   pal cli actor label <name>    Rename the actor — who caused a record
+ *   pal cli machine               Show this install's label and id
+ *   pal cli machine label <name>  Rename the machine — where a record was written
+ *
+ * Renaming touches no stored record: both subjects resolve a label on read, so
+ * an id already written into a thread or a reflection reads under the new name
+ * immediately. The registry entry is refreshed here so the change also travels
+ * on the next export.
+ */
+
+import {
+  actorFilePath,
+  ensureActorRegistered,
+  loadActor,
+  setActorLabel,
+} from "../hooks/lib/actor";
+import { shortId } from "../hooks/lib/identity-store";
+import {
+  ensureRegistered,
+  loadMachine,
+  machineFilePath,
+  setLabel,
+} from "../hooks/lib/machine";
+import { log } from "../targets/lib";
+
+export type IdentitySubject = "actor" | "machine";
+
+interface SubjectOps {
+  /** What the id names, for the one-line description. */
+  noun: string;
+  read(): { id: string; label: string };
+  rename(name: string): { id: string; label: string };
+  register(): void;
+  file(): string;
+}
+
+const SUBJECTS: Record<IdentitySubject, SubjectOps> = {
+  actor: {
+    noun: "who caused a record",
+    read: () => loadActor(),
+    rename: (name) => setActorLabel(name),
+    register: () => {
+      ensureActorRegistered();
+    },
+    file: () => actorFilePath(),
+  },
+  machine: {
+    noun: "where a record was written",
+    read: () => loadMachine(),
+    rename: (name) => {
+      const updated = setLabel(name);
+      return updated;
+    },
+    register: () => {
+      ensureRegistered();
+    },
+    file: () => machineFilePath(),
+  },
+};
+
+function show(subject: IdentitySubject): number {
+  const ops = SUBJECTS[subject];
+  const { id, label } = ops.read();
+  console.log(`${subject}: ${label} (${shortId(id)}) — ${ops.noun}`);
+  console.log(`  id:   ${id}`);
+  console.log(`  file: ${ops.file()}`);
+  return 0;
+}
+
+function rename(subject: IdentitySubject, name: string): number {
+  const ops = SUBJECTS[subject];
+  const before = ops.read();
+  const after = ops.rename(name);
+  ops.register();
+  if (after.label === before.label) {
+    log.info(`${subject} is already named ${after.label}`);
+    return 0;
+  }
+  log.success(`${subject} renamed: ${before.label} → ${after.label}`);
+  return 0;
+}
+
+export function runIdentity(subject: IdentitySubject, args: string[]): number {
+  const [action, ...rest] = args;
+
+  if (!action) return show(subject);
+
+  if (action === "label") {
+    const name = rest.join(" ").trim();
+    if (!name) {
+      log.error(`Usage: pal cli ${subject} label <name>`);
+      return 1;
+    }
+    return rename(subject, name);
+  }
+
+  log.error(`Unknown ${subject} action: ${action}`);
+  log.info(`Usage: pal cli ${subject} [label <name>]`);
+  return 1;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -244,6 +244,13 @@ async function runCli(command: string | undefined, args: string[]) {
       if (code !== 0) process.exit(code);
       break;
     }
+    case "actor":
+    case "machine": {
+      const { runIdentity } = await import("./identity");
+      const code = runIdentity(command, args);
+      if (code !== 0) process.exit(code);
+      break;
+    }
     case "debug":
       cliDebug(args);
       break;
@@ -288,6 +295,8 @@ function showHelp() {
     pal cli migrate [--list] [--dry-run]    Run pending data migrations
     pal cli analyze [--actionable]          Learning analysis: ratings, failure patterns, graduation candidates
     pal cli usage                           Summarize token usage and cost
+    pal cli actor [label <name>]            Show or rename this actor (who caused a record)
+    pal cli machine [label <name>]          Show or rename this install (where it was written)
     pal cli knowledge <sub> [args]          Query & manage the knowledge store
                                             (search · graph · stats · hubs · find · show · add · ls)
     pal cli skill link <name>               Link a personal ~/.pal/skills/<name>/ into installed agents
@@ -1178,6 +1187,11 @@ async function install(targets: Targets) {
   await promptIdentity();
   await promptTelos();
   await promptAttribution();
+
+  // After promptIdentity, so an actor minted before the name was known adopts it.
+  const { seedActorLabel, ensureActorRegistered } = await import("../hooks/lib/actor");
+  seedActorLabel();
+  ensureActorRegistered();
 
   // Shared, target-independent state. Every target installer used to repeat these
   // identical calls; AGENTS.md in particular must exist before any target symlinks

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -10,7 +10,13 @@
  * pending work without running anything.
  */
 
-import { existsSync, readdirSync, readFileSync, renameSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import { palHome, paths } from "../hooks/lib/paths";
 import {
@@ -423,11 +429,99 @@ const v4PathsToBindings: Migration = {
   },
 };
 
+// ── v5-attribution-keys: m → machine on stored records ─────────────
+
+/**
+ * Records stamped their origin as `m`, which nobody could decode without
+ * reading the writer. The stamp is now spelled out — machine, actor, runtime,
+ * authority — and this brings historical rows onto the same schema, because a
+ * mixed schema in an append-only store is exactly what makes it unauditable
+ * later. Nothing ever read `m`, so no consumer depends on the old spelling.
+ */
+function attributionFiles(): string[] {
+  const files = [paths.reflectionsFile(), resolve(paths.state(), "threads.jsonl")];
+  const signalsDir = paths.signals();
+  if (existsSync(signalsDir)) {
+    for (const name of readdirSync(signalsDir)) {
+      if (name.endsWith(".jsonl")) files.push(resolve(signalsDir, name));
+    }
+  }
+  return files.filter((f) => existsSync(f));
+}
+
+/** Lines carrying the old key. A line already using `machine` is left alone. */
+function renameAttributionKey(raw: string): { text: string; changed: number } {
+  const lines = raw.split("\n");
+  let changed = 0;
+
+  const out = lines.map((line) => {
+    if (!line.trim()) return line;
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return line; // a malformed line is left exactly as found
+    }
+    if (!("m" in record)) return line;
+
+    const { m, ...rest } = record;
+    changed++;
+    // `rest` spreads last so a record already carrying `machine` keeps that
+    // value and still sheds the stale `m`.
+    return JSON.stringify({ machine: m, ...rest });
+  });
+
+  return { text: out.join("\n"), changed };
+}
+
+function filesCarryingOldKey(): string[] {
+  return attributionFiles().filter(
+    (f) => renameAttributionKey(readFileSync(f, "utf-8")).changed > 0
+  );
+}
+
+const v5AttributionKeys: Migration = {
+  id: "v5-attribution-keys",
+  description: "Rename the origin stamp `m` to `machine` on stored records",
+
+  check() {
+    const stale = filesCarryingOldKey();
+    return {
+      pending: stale.length > 0,
+      detail:
+        stale.length > 0
+          ? `${stale.length} file(s) still stamp origin as \`m\``
+          : undefined,
+    };
+  },
+
+  run(dryRun = false): MigrationResult {
+    const results: string[] = [];
+    let migrated = 0;
+
+    for (const file of filesCarryingOldKey()) {
+      const { text, changed } = renameAttributionKey(readFileSync(file, "utf-8"));
+      const name = file.replace(palHome(), "").replaceAll("\\", "/");
+      if (dryRun) {
+        results.push(`${name}: would rewrite ${changed} record(s)`);
+        migrated++;
+        continue;
+      }
+      writeFileSync(file, text, "utf-8");
+      results.push(`${name}: ${changed} record(s) rewritten`);
+      migrated++;
+    }
+
+    return { migrated, skipped: 0, results };
+  },
+};
+
 const MIGRATIONS: Migration[] = [
   v1Projects,
   v2ThreadsToIsc,
   v3EntitiesToKnowledge,
   v4PathsToBindings,
+  v5AttributionKeys,
 ];
 
 // ── Public API ────────────────────────────────────────────────────

--- a/src/hooks/lib/actor.ts
+++ b/src/hooks/lib/actor.ts
@@ -27,6 +27,7 @@ import {
 } from "./identity-store";
 import { loadMachine } from "./machine";
 import { palHome, paths } from "./paths";
+import { identity } from "./settings";
 import { isPalSpawnedInference } from "./spawn-guard";
 
 export type ActorIdentity = IdentityBase;
@@ -126,6 +127,21 @@ export function ensureActorRegistered(home: string = palHome()): ActorIdentity {
   const actor = loadActor(home);
   writeActorEntry({ id: actor.id, label: actor.label });
   return actor;
+}
+
+/**
+ * Adopt the principal's name as the actor label, but only while the label is
+ * still the generated default — a chosen label is never overwritten. Runs at
+ * install rather than at mint, so an actor created before the name was known
+ * still picks it up. The settings default of "User" names nobody, so it is not
+ * adopted.
+ */
+export function seedActorLabel(home: string = palHome()): ActorIdentity {
+  const actor = loadActor(home);
+  if (actor.label !== defaultActorLabel(actor.id)) return actor;
+  const name = identity().principal.name.trim();
+  if (!name || name === "User") return actor;
+  return setActorLabel(name, home);
 }
 
 /** Authority behind the call currently executing. */

--- a/src/hooks/lib/actor.ts
+++ b/src/hooks/lib/actor.ts
@@ -1,0 +1,147 @@
+/**
+ * Actor identity — who caused a record, as distinct from where it was written.
+ *
+ * A machine id answers "which install"; it deliberately never crosses an export
+ * boundary, because two installs sharing one id breaks every origin-scoped
+ * read. An actor id answers "which person", and needs the opposite treatment:
+ * the same person on a laptop and a desktop is one actor, so `actor.json` lives
+ * under memory/ where the export picks it up and the import merge adopts it on
+ * an install that has none. An install that already has an actor keeps it — the
+ * merge treats a diverged file as a conflict and leaves the local side in place.
+ *
+ * Identity alone does not attribute an action. `currentAttribution()` is the
+ * stamp a record carries: the person, the install, the agent runtime they were
+ * driving, and whether a human turn was behind the call at all.
+ */
+
+import { resolve } from "node:path";
+import { type AgentType, getActiveAgent } from "./agent";
+import {
+  type IdentityBase,
+  loadIdentity,
+  readRegistryEntries,
+  relabelIdentity,
+  resolveDisplayName,
+  shortId,
+  writeRegistryEntry as writeEntry,
+} from "./identity-store";
+import { loadMachine } from "./machine";
+import { palHome, paths } from "./paths";
+import { isPalSpawnedInference } from "./spawn-guard";
+
+export type ActorIdentity = IdentityBase;
+
+/**
+ * Under what authority an action ran. `user` means a human turn drove it;
+ * `agent` means PAL spawned the inference itself and no human saw the call.
+ * This is the authority PAL can observe today — an approval a PAL-owned gate
+ * granted is a further distinction that gate has to introduce.
+ */
+export type Authority = "user" | "agent";
+
+/** The origin fields every attributable record carries. */
+export interface RecordAttribution {
+  /** Machine id — which install wrote it. */
+  m: string;
+  /** Actor id — which person caused it. */
+  a: string;
+  /** Agent runtime the actor was driving. */
+  rt: AgentType;
+  /** Whether a human turn was behind the call. */
+  au: Authority;
+}
+
+/**
+ * Unlike machine.json this sits inside memory/, so it is exported and can be
+ * adopted by a second install belonging to the same person.
+ */
+export function actorFilePath(home: string = palHome()): string {
+  return resolve(home, "memory", "actor.json");
+}
+
+function actorsDir(): string {
+  return resolve(paths.memory(), "actors");
+}
+
+/**
+ * Neutral default label, on the same reasoning as the machine default: the
+ * label travels in every exported registry entry, so a real name belongs there
+ * only once its owner has chosen to put it there.
+ */
+export function defaultActorLabel(id: string): string {
+  return `actor-${shortId(id)}`;
+}
+
+function newActor(): ActorIdentity {
+  const id = crypto.randomUUID();
+  return { id, label: defaultActorLabel(id), createdAt: new Date().toISOString() };
+}
+
+function repairActor(stored: Partial<ActorIdentity> & { id: string }): ActorIdentity {
+  return {
+    id: stored.id,
+    label: stored.label?.trim() || defaultActorLabel(stored.id),
+    createdAt: stored.createdAt || new Date().toISOString(),
+  };
+}
+
+/**
+ * This person's identity, minted on first call and stable afterwards — across
+ * machines, once an export has carried it there.
+ */
+export function loadActor(home: string = palHome()): ActorIdentity {
+  return loadIdentity(actorFilePath(home), newActor, repairActor);
+}
+
+/** Rename this actor. No stored record is touched — labels resolve on read. */
+export function setActorLabel(label: string, home: string = palHome()): ActorIdentity {
+  return relabelIdentity(actorFilePath(home), loadActor(home), label);
+}
+
+export interface ActorRegistryEntry {
+  id: string;
+  label: string;
+}
+
+/** Write (or refresh) an actor's registry entry. Registry entries are exported. */
+export function writeActorEntry(entry: ActorRegistryEntry, body = ""): string {
+  return writeEntry(actorsDir(), { ...entry }, body);
+}
+
+/** Every known actor, this one and any that arrived via import. */
+export function readActorRegistry(): ActorRegistryEntry[] {
+  return readRegistryEntries(actorsDir()).map((meta) => ({
+    id: meta.id,
+    label: meta.label,
+  }));
+}
+
+/** Name for a record's actor, falling back to the short id. */
+export function actorDisplayName(id: string, registry: ActorRegistryEntry[]): string {
+  return resolveDisplayName(id, registry);
+}
+
+/** Register this actor so their label resolves on anyone else's install. */
+export function ensureActorRegistered(home: string = palHome()): ActorIdentity {
+  const actor = loadActor(home);
+  writeActorEntry({ id: actor.id, label: actor.label });
+  return actor;
+}
+
+/** Authority behind the call currently executing. */
+export function currentAuthority(): Authority {
+  return isPalSpawnedInference() ? "agent" : "user";
+}
+
+/**
+ * The origin stamp for a record written right now. Every attributable writer
+ * spreads this instead of stamping a machine id alone.
+ */
+export function currentAttribution(): RecordAttribution {
+  return {
+    m: loadMachine().id,
+    a: loadActor().id,
+    rt: getActiveAgent(),
+    au: currentAuthority(),
+  };
+}

--- a/src/hooks/lib/actor.ts
+++ b/src/hooks/lib/actor.ts
@@ -40,16 +40,20 @@ export type ActorIdentity = IdentityBase;
  */
 export type Authority = "user" | "agent";
 
-/** The origin fields every attributable record carries. */
+/**
+ * The origin fields every attributable record carries. Spelled out rather than
+ * abbreviated: these rows are meant to be read by whoever is auditing them, and
+ * a key nobody can decode is the same as no key at all.
+ */
 export interface RecordAttribution {
-  /** Machine id — which install wrote it. */
-  m: string;
-  /** Actor id — which person caused it. */
-  a: string;
-  /** Agent runtime the actor was driving. */
-  rt: AgentType;
+  /** Which install wrote it. */
+  machine: string;
+  /** Which person caused it. */
+  actor: string;
+  /** Which agent the actor was driving — claude, codex, cursor, copilot, opencode. */
+  runtime: AgentType;
   /** Whether a human turn was behind the call. */
-  au: Authority;
+  authority: Authority;
 }
 
 /**
@@ -155,9 +159,9 @@ export function currentAuthority(): Authority {
  */
 export function currentAttribution(): RecordAttribution {
   return {
-    m: loadMachine().id,
-    a: loadActor().id,
-    rt: getActiveAgent(),
-    au: currentAuthority(),
+    machine: loadMachine().id,
+    actor: loadActor().id,
+    runtime: getActiveAgent(),
+    authority: currentAuthority(),
   };
 }

--- a/src/hooks/lib/export.ts
+++ b/src/hooks/lib/export.ts
@@ -6,6 +6,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import AdmZip from "adm-zip";
+import { ensureActorRegistered } from "./actor";
 import { ensureRegistered } from "./machine";
 import { palHome } from "./paths";
 
@@ -95,6 +96,7 @@ export function buildManifest(
 export function exportZip(outputPath: string): number {
   const root = palHome();
   const identity = ensureRegistered(root);
+  ensureActorRegistered(root);
   const files = collectExportFiles();
   if (files.length === 0) return 0;
 

--- a/src/hooks/lib/identity-store.ts
+++ b/src/hooks/lib/identity-store.ts
@@ -1,0 +1,138 @@
+/**
+ * Identity store — the mechanics shared by every kind of identity PAL keeps.
+ *
+ * PAL names two different subjects. A machine is the install a record came
+ * from; an actor is the person who caused it. They answer different questions
+ * and travel in opposite directions across an export boundary, but the storage
+ * problem is identical: a uuid that must never be regenerated, a label that
+ * resolves on read so a rename touches no stored record, and a registry of
+ * `<id>.md` entries so an id written on one install still reads as a name on
+ * another.
+ *
+ * Each subject supplies its own file location, its own extra fields, and its
+ * own default label. Everything below is the part that does not differ.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { parse, stringify } from "./frontmatter";
+
+export interface IdentityBase {
+  id: string;
+  label: string;
+  createdAt: string;
+}
+
+/** Frontmatter of one registry entry. Every value is a string on disk. */
+export type RegistryFields = Record<string, string> & { id: string; label: string };
+
+/** Anything the display resolver can name. Extra fields are ignored. */
+export interface NameableEntry {
+  id: string;
+  label: string;
+}
+
+const SHORT_ID_LENGTH = 4;
+
+/** First segment of the uuid — enough to disambiguate two same-labelled subjects. */
+export function shortId(id: string): string {
+  return id.replaceAll("-", "").slice(0, SHORT_ID_LENGTH);
+}
+
+function hasUsableId(value: unknown): value is { id: string } {
+  const v = value as { id?: unknown } | null;
+  return typeof v?.id === "string" && v.id.length > 0;
+}
+
+/** Persist a record, creating its directory if this is the first write. */
+function saveIdentity<T extends IdentityBase>(file: string, record: T): T {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
+
+/**
+ * Read a stored identity, or mint one on first call.
+ *
+ * The id is the only irreplaceable field — discarding one orphans every record
+ * that referenced it — so a file carrying a usable id is repaired rather than
+ * regenerated, and a file that has lost its id is treated as absent.
+ */
+export function loadIdentity<T extends IdentityBase>(
+  file: string,
+  create: () => T,
+  repair: (stored: Partial<T> & { id: string }) => T
+): T {
+  if (existsSync(file)) {
+    try {
+      const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
+      if (hasUsableId(parsed)) return repair(parsed as Partial<T> & { id: string });
+    } catch {
+      /* fall through to minting a fresh identity below */
+    }
+  }
+  return saveIdentity(file, create());
+}
+
+/** Change a label without touching any stored record — labels resolve on read. */
+export function relabelIdentity<T extends IdentityBase>(
+  file: string,
+  current: T,
+  label: string
+): T {
+  return saveIdentity(file, { ...current, label: label.trim() || current.label });
+}
+
+function entryPath(dir: string, id: string): string {
+  return resolve(dir, `${id}.md`);
+}
+
+/** Write (or refresh) a registry entry. Registry entries are exported. */
+export function writeRegistryEntry(
+  dir: string,
+  fields: RegistryFields,
+  body = ""
+): string {
+  mkdirSync(dir, { recursive: true });
+  const file = entryPath(dir, fields.id);
+  const existingBody = existsSync(file) ? parse(readFileSync(file, "utf-8")).body : "";
+  writeFileSync(
+    file,
+    stringify({ ...fields, updated: new Date().toISOString() }, body || existingBody)
+  );
+  return file;
+}
+
+/**
+ * Every entry in a registry directory. Only `.md` files count, and an entry
+ * missing an id or a label is dropped — a malformed one must not hide the rest.
+ */
+export function readRegistryEntries(dir: string): RegistryFields[] {
+  mkdirSync(dir, { recursive: true });
+  const entries: RegistryFields[] = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".md")) continue;
+    try {
+      const { meta } = parse<Record<string, string>>(
+        readFileSync(resolve(dir, name), "utf-8")
+      );
+      if (meta.id && meta.label) entries.push(meta as RegistryFields);
+    } catch {
+      /* a malformed entry must not hide the rest of the registry */
+    }
+  }
+  return entries;
+}
+
+/**
+ * Name for a record's id. Unknown ids fall back to the short id so a record
+ * whose registry entry has not arrived yet still reads sensibly. A label shared
+ * by two subjects is suffixed rather than deduplicated — the registry is not
+ * always reachable, so uniqueness can never be enforced.
+ */
+export function resolveDisplayName(id: string, registry: NameableEntry[]): string {
+  const entry = registry.find((e) => e.id === id);
+  if (!entry) return shortId(id);
+  const sharesLabel = registry.some((e) => e.id !== id && e.label === entry.label);
+  return sharesLabel ? `${entry.label}·${shortId(id)}` : entry.label;
+}

--- a/src/hooks/lib/machine.ts
+++ b/src/hooks/lib/machine.ts
@@ -1,44 +1,42 @@
 /**
- * Machine identity — who this install is, and how a record's origin becomes a
- * name at display time.
- *
- * Records store the id and never the label. Resolution happens on read, so
- * renaming a machine is a one-file edit that no stored record notices, and two
- * machines sharing a label is a display concern rather than a data collision.
+ * Machine identity — which install a record came from.
  *
  * `machine.json` lives at the PAL_HOME root, outside every exported directory,
  * because importing it would give two installs one id and silently break every
- * origin-scoped read built on top of it.
+ * origin-scoped read built on top of it. Contrast with actor.ts, whose file
+ * lives under memory/ precisely so it does travel: one person on two machines
+ * is one actor, but never one machine.
+ *
+ * The storage mechanics live in identity-store.ts; this module supplies the
+ * machine-specific parts — where the file lives, the `os` field, and a label
+ * that is deliberately not the hostname.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { platform as osPlatform } from "node:os";
 import { resolve } from "node:path";
-import { parse, stringify } from "./frontmatter";
+import {
+  type IdentityBase,
+  loadIdentity,
+  readRegistryEntries,
+  relabelIdentity,
+  resolveDisplayName,
+  shortId,
+  writeRegistryEntry as writeEntry,
+} from "./identity-store";
 import { palHome, paths } from "./paths";
 
-export interface MachineIdentity {
-  id: string;
-  label: string;
+export interface MachineIdentity extends IdentityBase {
   os: string;
-  createdAt: string;
 }
 
-const SHORT_ID_LENGTH = 4;
+export { shortId };
 
 export function machineFilePath(home: string = palHome()): string {
   return resolve(home, "machine.json");
 }
 
 function machinesDir(): string {
-  const dir = resolve(paths.memory(), "machines");
-  mkdirSync(dir, { recursive: true });
-  return dir;
-}
-
-/** First segment of the uuid — enough to disambiguate two same-labelled machines. */
-export function shortId(id: string): string {
-  return id.replaceAll("-", "").slice(0, SHORT_ID_LENGTH);
+  return resolve(paths.memory(), "machines");
 }
 
 /**
@@ -60,16 +58,6 @@ function newIdentity(): MachineIdentity {
   };
 }
 
-function hasUsableId(value: unknown): value is Partial<MachineIdentity> & { id: string } {
-  const v = value as Partial<MachineIdentity> | null;
-  return typeof v?.id === "string" && v.id.length > 0;
-}
-
-/**
- * Fill in whatever a stored identity is missing. Only the id is irreplaceable —
- * discarding one orphans every record that referenced it — so a file carrying a
- * usable id is repaired rather than regenerated.
- */
 function repair(stored: Partial<MachineIdentity> & { id: string }): MachineIdentity {
   return {
     id: stored.id,
@@ -85,27 +73,12 @@ function repair(stored: Partial<MachineIdentity> & { id: string }): MachineIdent
  * that referenced the old one.
  */
 export function loadMachine(home: string = palHome()): MachineIdentity {
-  const file = machineFilePath(home);
-  if (existsSync(file)) {
-    try {
-      const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-      if (hasUsableId(parsed)) return repair(parsed);
-    } catch {
-      /* fall through to regeneration below */
-    }
-  }
-  const identity = newIdentity();
-  mkdirSync(home, { recursive: true });
-  writeFileSync(file, `${JSON.stringify(identity, null, 2)}\n`);
-  return identity;
+  return loadIdentity(machineFilePath(home), newIdentity, repair);
 }
 
 /** Rename this machine. No stored record is touched — labels resolve on read. */
 export function setLabel(label: string, home: string = palHome()): MachineIdentity {
-  const current = loadMachine(home);
-  const updated = { ...current, label: label.trim() || current.label };
-  writeFileSync(machineFilePath(home), `${JSON.stringify(updated, null, 2)}\n`);
-  return updated;
+  return relabelIdentity(machineFilePath(home), loadMachine(home), label);
 }
 
 export interface RegistryEntry {
@@ -114,58 +87,23 @@ export interface RegistryEntry {
   os: string;
 }
 
-function registryPath(id: string): string {
-  return resolve(machinesDir(), `${id}.md`);
-}
-
 /** Write (or refresh) a machine's registry entry. Registry entries are exported. */
 export function writeRegistryEntry(entry: RegistryEntry, body = ""): string {
-  const file = registryPath(entry.id);
-  const existingBody = existsSync(file) ? parse(readFileSync(file, "utf-8")).body : "";
-  const content = stringify(
-    {
-      id: entry.id,
-      label: entry.label,
-      os: entry.os,
-      updated: new Date().toISOString(),
-    },
-    body || existingBody
-  );
-  writeFileSync(file, content);
-  return file;
+  return writeEntry(machinesDir(), { ...entry }, body);
 }
 
 /** Every known machine, this one and any that arrived via import. */
 export function readRegistry(): RegistryEntry[] {
-  const dir = machinesDir();
-  const entries: RegistryEntry[] = [];
-  for (const name of readdirSync(dir)) {
-    if (!name.endsWith(".md")) continue;
-    try {
-      const meta = parse<Record<string, string>>(
-        readFileSync(resolve(dir, name), "utf-8")
-      ).meta;
-      if (meta.id && meta.label) {
-        entries.push({ id: meta.id, label: meta.label, os: meta.os ?? "" });
-      }
-    } catch {
-      /* a malformed entry must not hide the rest of the registry */
-    }
-  }
-  return entries;
+  return readRegistryEntries(machinesDir()).map((meta) => ({
+    id: meta.id,
+    label: meta.label,
+    os: meta.os ?? "",
+  }));
 }
 
-/**
- * Name for a record's origin id. Unknown ids fall back to the short id so a
- * record from a machine whose entry has not arrived yet still reads sensibly.
- * A label shared by two machines is suffixed rather than deduplicated — the
- * registry is not always reachable, so uniqueness can never be enforced.
- */
+/** Name for a record's origin machine, falling back to the short id. */
 export function displayName(id: string, registry: RegistryEntry[]): string {
-  const entry = registry.find((e) => e.id === id);
-  if (!entry) return shortId(id);
-  const sharesLabel = registry.some((e) => e.id !== id && e.label === entry.label);
-  return sharesLabel ? `${entry.label}·${shortId(id)}` : entry.label;
+  return resolveDisplayName(id, registry);
 }
 
 /** Register this install so its label can be resolved on any machine. */

--- a/src/hooks/lib/relationship.ts
+++ b/src/hooks/lib/relationship.ts
@@ -47,16 +47,26 @@ function dedup(notes: RelationshipNote[], filepath: string): RelationshipNote[] 
   }
 }
 
-/** Append notes to today's relationship file */
-export function appendNotes(notes: RelationshipNote[], sessionId?: string): void {
-  if (notes.length === 0) return;
+/** What an append actually did — `written` is the count after deduplication. */
+export interface AppendResult {
+  file: string;
+  written: number;
+}
 
+/**
+ * Append notes to today's relationship file. Reports the file and the number of
+ * notes that survived deduplication, which is what a caller must report rather
+ * than the count it passed in.
+ */
+export function appendNotes(notes: RelationshipNote[], sessionId?: string): AppendResult {
   const filepath = dailyFilePath(new Date());
+  if (notes.length === 0) return { file: filepath, written: 0 };
+
   const today = new Date().toISOString().slice(0, 10);
 
   // Deduplicate against existing content
   const fresh = dedup(notes, filepath);
-  if (fresh.length === 0) return;
+  if (fresh.length === 0) return { file: filepath, written: 0 };
 
   const lines: string[] = [];
 
@@ -81,6 +91,7 @@ export function appendNotes(notes: RelationshipNote[], sessionId?: string): void
 
   const existing = existsSync(filepath) ? readFileSync(filepath, "utf-8") : "";
   writeFileSync(filepath, existing + lines.join("\n"), "utf-8");
+  return { file: filepath, written: fresh.length };
 }
 
 /** Load notes from the last N days as a single string */

--- a/src/hooks/lib/signals.ts
+++ b/src/hooks/lib/signals.ts
@@ -1,6 +1,6 @@
 import { appendFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { loadMachine } from "./machine";
+import { currentAttribution } from "./actor";
 import { paths } from "./paths";
 import { now } from "./time";
 
@@ -15,7 +15,7 @@ function emitSignal(
   filename: string,
   data: { type: string; [key: string]: unknown }
 ): void {
-  const signal: Signal = { ts: now(), m: loadMachine().id, ...data };
+  const signal: Signal = { ts: now(), ...currentAttribution(), ...data };
   const filepath = resolve(paths.signals(), filename);
   appendFileSync(filepath, `${JSON.stringify(signal)}\n`);
 }

--- a/src/tools/agent/algorithm-reflect.ts
+++ b/src/tools/agent/algorithm-reflect.ts
@@ -155,7 +155,11 @@ Output: algorithm-reflections.jsonl in memory/learning/reflections/
   });
 
   const result = appendReflection(reflection);
-  emit.ok(result.message);
+  emit.receipt(result.path, {
+    passed: reflection.criteria_passed,
+    of: reflection.criteria_count,
+    scope: reflection.scope,
+  });
 }
 
 if (import.meta.main) run();

--- a/src/tools/agent/algorithm-reflect.ts
+++ b/src/tools/agent/algorithm-reflect.ts
@@ -15,17 +15,16 @@
 
 import { appendFileSync } from "node:fs";
 import { parseArgs } from "node:util";
+import { currentAttribution, type RecordAttribution } from "../../hooks/lib/actor";
 import { encodeAnchor } from "../../hooks/lib/anchor";
-import { loadMachine } from "../../hooks/lib/machine";
 import { paths } from "../../hooks/lib/paths";
 import { emit } from "../lib/emit";
 
 // ── Types ──
 
-interface AlgorithmReflection {
+interface AlgorithmReflection extends RecordAttribution {
   timestamp: string;
   cwd: string;
-  m: string;
   task: string;
   criteria_count: number;
   criteria_passed: number;
@@ -64,7 +63,7 @@ export function buildReflection(input: {
   return {
     timestamp: new Date().toISOString(),
     cwd: encodeAnchor(process.cwd()),
-    m: loadMachine().id,
+    ...currentAttribution(),
     task: input.task,
     criteria_count: input.criteria_count ?? 0,
     criteria_passed: input.criteria_passed ?? 0,

--- a/src/tools/agent/handoff-note.ts
+++ b/src/tools/agent/handoff-note.ts
@@ -39,10 +39,12 @@ function readHandoffs(): Record<string, HandoffEntry> {
   }
 }
 
-function writeHandoffs(handoffs: Record<string, HandoffEntry>): void {
+/** Returns how many entries survived the trim, which is what the receipt reports. */
+function writeHandoffs(handoffs: Record<string, HandoffEntry>): number {
   const entries = Object.entries(handoffs);
   const trimmed = entries.length > 20 ? Object.fromEntries(entries.slice(-20)) : handoffs;
   writeFileSync(handoffPath(), JSON.stringify(trimmed, null, 2), "utf-8");
+  return Object.keys(trimmed).length;
 }
 
 function writeHandoffNote(
@@ -50,7 +52,7 @@ function writeHandoffNote(
   title: string,
   text: string,
   done: boolean
-): { success: boolean; message: string } {
+): { file: string; status: HandoffEntry["status"]; kept: number } {
   const handoffs = readHandoffs();
   handoffs[cwd] = {
     timestamp: new Date().toISOString(),
@@ -60,11 +62,8 @@ function writeHandoffNote(
     artifacts: [],
     source: "deliberate",
   };
-  writeHandoffs(handoffs);
-  return {
-    success: true,
-    message: done ? "Handoff cleared (marked completed)" : "Handoff note written",
-  };
+  const kept = writeHandoffs(handoffs);
+  return { file: handoffPath(), status: handoffs[cwd].status, kept };
 }
 
 function run() {
@@ -103,7 +102,7 @@ Output: writes to memory/state/last-handoff.json keyed by cwd
       values.text || "",
       true
     );
-    emit.ok(result.message);
+    emit.receipt(result.file, { status: result.status, entries: result.kept });
     process.exit(0);
   }
 
@@ -113,7 +112,7 @@ Output: writes to memory/state/last-handoff.json keyed by cwd
   }
 
   const result = writeHandoffNote(process.cwd(), values.title, values.text, false);
-  emit.ok(result.message);
+  emit.receipt(result.file, { status: result.status, entries: result.kept });
 }
 
 if (import.meta.main) run();

--- a/src/tools/agent/relationship-note.ts
+++ b/src/tools/agent/relationship-note.ts
@@ -82,9 +82,8 @@ Output: appends to memory/relationship/YYYY-MM/YYYY-MM-DD.md
     notes.push({ type: "Session" as const, text: values.b });
   }
 
-  appendNotes(notes);
-
-  emit.ok(`Relationship note written (${notes.length})`);
+  const { file, written } = appendNotes(notes);
+  emit.receipt(file, { written, deduped: notes.length - written });
 }
 
 if (import.meta.main) run();

--- a/src/tools/agent/thread.ts
+++ b/src/tools/agent/thread.ts
@@ -14,17 +14,16 @@
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
+import { currentAttribution, type RecordAttribution } from "../../hooks/lib/actor";
 import { encodeAnchor } from "../../hooks/lib/anchor";
-import { loadMachine } from "../../hooks/lib/machine";
 import { ensureDir, paths } from "../../hooks/lib/paths";
 import { emit } from "../lib/emit";
 
 // ── Types ──
 
-export interface Thread {
+export interface Thread extends RecordAttribution {
   id: string;
   cwd: string;
-  m: string;
   title: string;
   context: string;
   status: "open" | "resolved";
@@ -70,7 +69,7 @@ export function addThread(title: string, context: string): Thread {
   const thread: Thread = {
     id: generateId(),
     cwd: encodeAnchor(process.cwd()),
-    m: loadMachine().id,
+    ...currentAttribution(),
     title,
     context,
     status: "open",

--- a/src/tools/agent/wisdom-frame.ts
+++ b/src/tools/agent/wisdom-frame.ts
@@ -234,7 +234,7 @@ Examples:
 
   const cliType = (values.type || "evolution") as ObservationType;
   const result = updateFrame(values.domain, values.observation, cliType);
-  emit.ok(result.message);
+  emit.receipt(result.framePath, { domain: result.domain, type: result.type });
 }
 
 if (import.meta.main) run();

--- a/src/tools/lib/emit.ts
+++ b/src/tools/lib/emit.ts
@@ -4,12 +4,24 @@
  * confirmations are pure noise that costs context tokens; a human at a TTY wants
  * them. Gate on the TTY signal, with PAL_VERBOSE / PAL_QUIET as explicit overrides.
  *
- *   data()  requested payload — ALWAYS emitted (list output, reports, results)
- *   ok()    success confirmation / progress — only at a TTY or under PAL_VERBOSE
+ *   data()     requested payload — ALWAYS emitted (list output, reports, results)
+ *   receipt()  proof a write landed — ALWAYS emitted (see below)
+ *   ok()       success confirmation / progress — only at a TTY or under PAL_VERBOSE
  *
  * Errors stay on console.error (stderr) + a non-zero exit — always surfaced,
  * independent of this gate.
+ *
+ * Why receipt() is not gated: a state-changing call's confirmation is its
+ * payload, not progress chatter. Without it a caller cannot tell what landed or
+ * where, and re-reads the file to find out — which costs far more context than
+ * the one line the gate saved. The receipt reports what was actually written,
+ * so a writer that deduplicates or trims must report the real count rather than
+ * what it was handed. `no-silent-write` in klint.rules.ts enforces that every
+ * tool writing to disk emits one.
  */
+
+import { relative } from "node:path";
+import { palHome } from "../../hooks/lib/paths";
 
 function isVerbose(): boolean {
   if (process.env.PAL_QUIET === "1") return false;
@@ -21,11 +33,28 @@ function line(stream: { write: (s: string) => void }, text: string): void {
   stream.write(text.endsWith("\n") ? text : `${text}\n`);
 }
 
+/**
+ * Paths are reported relative to PAL_HOME so a receipt reads the same on every
+ * machine, and never discloses an absolute home path. A file outside PAL_HOME
+ * keeps its own path — a "../.." chain would name nothing useful.
+ */
+function homeRelative(file: string): string {
+  const rel = relative(palHome(), file).replaceAll("\\", "/");
+  return rel && !rel.startsWith("..") ? rel : file.replaceAll("\\", "/");
+}
+
 export const emit = {
   data(text: string): void {
     line(process.stdout, text);
   },
   ok(text: string): void {
     if (isVerbose()) line(process.stdout, text);
+  },
+  /** Proof that a write landed: the file it went to, plus what the operation produced. */
+  receipt(file: string, extra: Record<string, unknown> = {}): void {
+    line(
+      process.stdout,
+      JSON.stringify({ ok: true, wrote: homeRelative(file), ...extra })
+    );
   },
 };

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -56,6 +56,13 @@ describe("loadActor", () => {
     expect(Number.isNaN(Date.parse(a.createdAt))).toBe(false);
   });
 
+  test("a whitespace-only stored label falls back to the default", async () => {
+    const { loadActor, actorFilePath, defaultActorLabel } = await lib();
+    mkdirSync(resolve(HOME, "memory"), { recursive: true });
+    writeFileSync(actorFilePath(HOME), JSON.stringify({ id: "kept-id", label: "   " }));
+    expect(loadActor(HOME).label).toBe(defaultActorLabel("kept-id"));
+  });
+
   test("an empty id is not usable and is regenerated", async () => {
     const { loadActor, actorFilePath } = await lib();
     mkdirSync(resolve(HOME, "memory"), { recursive: true });

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+let HOME: string;
+
+beforeEach(() => {
+  HOME = mkdtempSync(resolve(tmpdir(), "pal-actor-"));
+  process.env.PAL_HOME = HOME;
+  delete process.env.PAL_SPAWNED_INFERENCE;
+  delete process.env.PAL_AGENT;
+});
+
+afterEach(() => {
+  delete process.env.PAL_HOME;
+  delete process.env.PAL_SPAWNED_INFERENCE;
+  delete process.env.PAL_AGENT;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+async function lib() {
+  return await import("../src/hooks/lib/actor");
+}
+
+describe("loadActor", () => {
+  test("creates memory/actor.json on first call with a uuid", async () => {
+    const { loadActor, actorFilePath } = await lib();
+    const a = loadActor(HOME);
+    expect(a.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(actorFilePath(HOME)).toBe(resolve(HOME, "memory", "actor.json"));
+    expect(existsSync(actorFilePath(HOME))).toBe(true);
+  });
+
+  test("returns the same id on every subsequent call", async () => {
+    const { loadActor } = await lib();
+    expect(loadActor(HOME).id).toBe(loadActor(HOME).id);
+  });
+
+  test("regenerates when the file is corrupt rather than throwing", async () => {
+    const { loadActor, actorFilePath } = await lib();
+    mkdirSync(resolve(HOME, "memory"), { recursive: true });
+    writeFileSync(actorFilePath(HOME), "not json at all");
+    expect(loadActor(HOME).id.length).toBeGreaterThan(0);
+  });
+
+  test("REPAIRS rather than regenerates when the id survives", async () => {
+    const { loadActor, actorFilePath, defaultActorLabel } = await lib();
+    mkdirSync(resolve(HOME, "memory"), { recursive: true });
+    writeFileSync(actorFilePath(HOME), JSON.stringify({ id: "kept-id" }));
+    const a = loadActor(HOME);
+    expect(a.id).toBe("kept-id");
+    expect(a.label).toBe(defaultActorLabel("kept-id"));
+    expect(Number.isNaN(Date.parse(a.createdAt))).toBe(false);
+  });
+
+  test("an empty id is not usable and is regenerated", async () => {
+    const { loadActor, actorFilePath } = await lib();
+    mkdirSync(resolve(HOME, "memory"), { recursive: true });
+    writeFileSync(actorFilePath(HOME), JSON.stringify({ id: "", label: "x" }));
+    expect(loadActor(HOME).id.length).toBeGreaterThan(0);
+  });
+});
+
+describe("defaultActorLabel", () => {
+  test("is derived from the id, never from the principal's name", async () => {
+    const { defaultActorLabel } = await lib();
+    expect(defaultActorLabel("9f2c8e14-1111-2222-3333-444455556666")).toBe("actor-9f2c");
+  });
+});
+
+describe("setActorLabel", () => {
+  test("changes the label while keeping the id", async () => {
+    const { loadActor, setActorLabel } = await lib();
+    const before = loadActor(HOME);
+    const after = setActorLabel("rico", HOME);
+    expect(after.label).toBe("rico");
+    expect(after.id).toBe(before.id);
+    expect(loadActor(HOME).label).toBe("rico");
+  });
+
+  test("ignores an empty label instead of clearing the name", async () => {
+    const { setActorLabel } = await lib();
+    setActorLabel("rico", HOME);
+    expect(setActorLabel("   ", HOME).label).toBe("rico");
+  });
+});
+
+describe("actor registry", () => {
+  test("ensureActorRegistered writes an entry under memory/actors", async () => {
+    const { ensureActorRegistered } = await lib();
+    const a = ensureActorRegistered(HOME);
+    expect(existsSync(resolve(HOME, "memory", "actors", `${a.id}.md`))).toBe(true);
+  });
+
+  test("readActorRegistry returns every written actor", async () => {
+    const { writeActorEntry, readActorRegistry } = await lib();
+    writeActorEntry({ id: "id-a", label: "rico" });
+    writeActorEntry({ id: "id-b", label: "mate" });
+    expect(
+      readActorRegistry()
+        .map((e) => e.label)
+        .sort()
+    ).toEqual(["mate", "rico"]);
+  });
+
+  test("re-registering updates the label without duplicating the entry", async () => {
+    const { writeActorEntry, readActorRegistry } = await lib();
+    writeActorEntry({ id: "id-a", label: "rico" });
+    writeActorEntry({ id: "id-a", label: "renamed" });
+    const reg = readActorRegistry();
+    expect(reg.length).toBe(1);
+    expect(reg[0].label).toBe("renamed");
+  });
+
+  test("actorDisplayName resolves a known id and falls back to the short id", async () => {
+    const { actorDisplayName } = await lib();
+    const reg = [{ id: "id-a", label: "rico" }];
+    expect(actorDisplayName("id-a", reg)).toBe("rico");
+    expect(actorDisplayName("ffff9999-0000-0000-0000-000000000000", [])).toBe("ffff");
+  });
+
+  test("suffixes with the short id when two actors share a label", async () => {
+    const { actorDisplayName } = await lib();
+    const reg = [
+      { id: "aaaa1111-0000-0000-0000-000000000000", label: "rico" },
+      { id: "bbbb2222-0000-0000-0000-000000000000", label: "rico" },
+    ];
+    expect(actorDisplayName("aaaa1111-0000-0000-0000-000000000000", reg)).toBe(
+      "rico·aaaa"
+    );
+  });
+});
+
+describe("actor identity is distinct from machine identity", () => {
+  test("the actor id is not the machine id", async () => {
+    const { loadActor } = await lib();
+    const { loadMachine } = await import("../src/hooks/lib/machine");
+    expect(loadActor(HOME).id).not.toBe(loadMachine(HOME).id);
+  });
+
+  test("actor.json TRAVELS in an export, unlike machine.json", async () => {
+    const { loadActor } = await lib();
+    const { loadMachine } = await import("../src/hooks/lib/machine");
+    loadActor(HOME);
+    loadMachine(HOME);
+    const { collectExportFiles } = await import("../src/hooks/lib/export");
+    const files = collectExportFiles();
+    expect(files).toContain("memory/actor.json");
+    expect(files.some((f) => f.endsWith("machine.json"))).toBe(false);
+  });
+
+  test("actor registry entries travel too, so a peer's label resolves", async () => {
+    const { ensureActorRegistered } = await lib();
+    const a = ensureActorRegistered(HOME);
+    const { collectExportFiles } = await import("../src/hooks/lib/export");
+    expect(collectExportFiles()).toContain(`memory/actors/${a.id}.md`);
+  });
+
+  test("actor.json is ALLOWED at the import boundary where machine.json is not", async () => {
+    const { isNeverImport } = await import("../src/hooks/lib/import-merge");
+    expect(isNeverImport("memory/actor.json")).toBe(false);
+    expect(isNeverImport("machine.json")).toBe(true);
+  });
+});
+
+describe("currentAttribution", () => {
+  test("stamps machine, actor, runtime and authority", async () => {
+    const { currentAttribution } = await lib();
+    const { loadMachine } = await import("../src/hooks/lib/machine");
+    process.env.PAL_AGENT = "codex";
+    const stamp = currentAttribution();
+    expect(stamp.m).toBe(loadMachine(HOME).id);
+    expect(stamp.a.length).toBeGreaterThan(0);
+    expect(stamp.rt).toBe("codex");
+    expect(stamp.au).toBe("user");
+  });
+
+  test("authority is 'agent' inside a PAL-spawned inference", async () => {
+    const { currentAttribution, currentAuthority } = await lib();
+    process.env.PAL_SPAWNED_INFERENCE = "1";
+    expect(currentAuthority()).toBe("agent");
+    expect(currentAttribution().au).toBe("agent");
+  });
+
+  test("the same actor is stamped regardless of which runtime is driving", async () => {
+    const { currentAttribution } = await lib();
+    process.env.PAL_AGENT = "claude";
+    const fromClaude = currentAttribution();
+    process.env.PAL_AGENT = "cursor";
+    const fromCursor = currentAttribution();
+    expect(fromCursor.a).toBe(fromClaude.a);
+    expect(fromCursor.rt).not.toBe(fromClaude.rt);
+  });
+});
+
+describe("records carry the attribution stamp", () => {
+  test("a thread records actor, runtime and authority alongside the machine", async () => {
+    const { addThread } = await import("../src/tools/agent/thread");
+    const { loadActor } = await lib();
+    process.env.PAL_AGENT = "claude";
+    const t = addThread("a title", "some context");
+    expect(t.a).toBe(loadActor(HOME).id);
+    expect(t.m.length).toBeGreaterThan(0);
+    expect(t.rt).toBe("claude");
+    expect(t.au).toBe("user");
+  });
+});

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -179,17 +179,17 @@ describe("currentAttribution", () => {
     const { loadMachine } = await import("../src/hooks/lib/machine");
     process.env.PAL_AGENT = "codex";
     const stamp = currentAttribution();
-    expect(stamp.m).toBe(loadMachine(HOME).id);
-    expect(stamp.a.length).toBeGreaterThan(0);
-    expect(stamp.rt).toBe("codex");
-    expect(stamp.au).toBe("user");
+    expect(stamp.machine).toBe(loadMachine(HOME).id);
+    expect(stamp.actor.length).toBeGreaterThan(0);
+    expect(stamp.runtime).toBe("codex");
+    expect(stamp.authority).toBe("user");
   });
 
   test("authority is 'agent' inside a PAL-spawned inference", async () => {
     const { currentAttribution, currentAuthority } = await lib();
     process.env.PAL_SPAWNED_INFERENCE = "1";
     expect(currentAuthority()).toBe("agent");
-    expect(currentAttribution().au).toBe("agent");
+    expect(currentAttribution().authority).toBe("agent");
   });
 
   test("the same actor is stamped regardless of which runtime is driving", async () => {
@@ -198,8 +198,8 @@ describe("currentAttribution", () => {
     const fromClaude = currentAttribution();
     process.env.PAL_AGENT = "cursor";
     const fromCursor = currentAttribution();
-    expect(fromCursor.a).toBe(fromClaude.a);
-    expect(fromCursor.rt).not.toBe(fromClaude.rt);
+    expect(fromCursor.actor).toBe(fromClaude.actor);
+    expect(fromCursor.runtime).not.toBe(fromClaude.runtime);
   });
 });
 
@@ -209,9 +209,9 @@ describe("records carry the attribution stamp", () => {
     const { loadActor } = await lib();
     process.env.PAL_AGENT = "claude";
     const t = addThread("a title", "some context");
-    expect(t.a).toBe(loadActor(HOME).id);
-    expect(t.m.length).toBeGreaterThan(0);
-    expect(t.rt).toBe("claude");
-    expect(t.au).toBe("user");
+    expect(t.actor).toBe(loadActor(HOME).id);
+    expect(t.machine.length).toBeGreaterThan(0);
+    expect(t.runtime).toBe("claude");
+    expect(t.authority).toBe("user");
   });
 });

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -82,16 +82,16 @@ describe("setActorLabel", () => {
   test("changes the label while keeping the id", async () => {
     const { loadActor, setActorLabel } = await lib();
     const before = loadActor(HOME);
-    const after = setActorLabel("rico", HOME);
-    expect(after.label).toBe("rico");
+    const after = setActorLabel("ada", HOME);
+    expect(after.label).toBe("ada");
     expect(after.id).toBe(before.id);
-    expect(loadActor(HOME).label).toBe("rico");
+    expect(loadActor(HOME).label).toBe("ada");
   });
 
   test("ignores an empty label instead of clearing the name", async () => {
     const { setActorLabel } = await lib();
-    setActorLabel("rico", HOME);
-    expect(setActorLabel("   ", HOME).label).toBe("rico");
+    setActorLabel("ada", HOME);
+    expect(setActorLabel("   ", HOME).label).toBe("ada");
   });
 });
 
@@ -104,18 +104,18 @@ describe("actor registry", () => {
 
   test("readActorRegistry returns every written actor", async () => {
     const { writeActorEntry, readActorRegistry } = await lib();
-    writeActorEntry({ id: "id-a", label: "rico" });
-    writeActorEntry({ id: "id-b", label: "mate" });
+    writeActorEntry({ id: "id-a", label: "ada" });
+    writeActorEntry({ id: "id-b", label: "grace" });
     expect(
       readActorRegistry()
         .map((e) => e.label)
         .sort()
-    ).toEqual(["mate", "rico"]);
+    ).toEqual(["ada", "grace"]);
   });
 
   test("re-registering updates the label without duplicating the entry", async () => {
     const { writeActorEntry, readActorRegistry } = await lib();
-    writeActorEntry({ id: "id-a", label: "rico" });
+    writeActorEntry({ id: "id-a", label: "ada" });
     writeActorEntry({ id: "id-a", label: "renamed" });
     const reg = readActorRegistry();
     expect(reg.length).toBe(1);
@@ -124,19 +124,19 @@ describe("actor registry", () => {
 
   test("actorDisplayName resolves a known id and falls back to the short id", async () => {
     const { actorDisplayName } = await lib();
-    const reg = [{ id: "id-a", label: "rico" }];
-    expect(actorDisplayName("id-a", reg)).toBe("rico");
+    const reg = [{ id: "id-a", label: "ada" }];
+    expect(actorDisplayName("id-a", reg)).toBe("ada");
     expect(actorDisplayName("ffff9999-0000-0000-0000-000000000000", [])).toBe("ffff");
   });
 
   test("suffixes with the short id when two actors share a label", async () => {
     const { actorDisplayName } = await lib();
     const reg = [
-      { id: "aaaa1111-0000-0000-0000-000000000000", label: "rico" },
-      { id: "bbbb2222-0000-0000-0000-000000000000", label: "rico" },
+      { id: "aaaa1111-0000-0000-0000-000000000000", label: "ada" },
+      { id: "bbbb2222-0000-0000-0000-000000000000", label: "ada" },
     ];
     expect(actorDisplayName("aaaa1111-0000-0000-0000-000000000000", reg)).toBe(
-      "rico·aaaa"
+      "ada·aaaa"
     );
   });
 });

--- a/test/algorithm-reflect-build.test.ts
+++ b/test/algorithm-reflect-build.test.ts
@@ -26,7 +26,7 @@ describe("buildReflection", () => {
     const { buildReflection } = await lib();
     const r = buildReflection(MIN_INPUT);
     const machineFile = JSON.parse(readFileSync(resolve(HOME, "machine.json"), "utf-8"));
-    expect(r.m).toBe(machineFile.id);
+    expect(r.machine).toBe(machineFile.id);
   });
 
   test("anchors the cwd when it falls inside a registered project", async () => {

--- a/test/cli-identity.test.ts
+++ b/test/cli-identity.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+let HOME: string;
+
+function writeSettings(principalName: string | undefined): void {
+  mkdirSync(resolve(HOME, "memory"), { recursive: true });
+  writeFileSync(
+    resolve(HOME, "memory", "pal-settings.json"),
+    JSON.stringify({
+      identity: { ai: { name: "Jarvis" }, principal: { name: principalName } },
+    })
+  );
+}
+
+beforeEach(() => {
+  HOME = mkdtempSync(resolve(tmpdir(), "pal-identity-cli-"));
+  process.env.PAL_HOME = HOME;
+});
+
+afterEach(() => {
+  delete process.env.PAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+async function actorLib() {
+  return await import("../src/hooks/lib/actor");
+}
+
+describe("seedActorLabel", () => {
+  test("adopts the principal's name while the label is still the default", async () => {
+    writeSettings("Rico");
+    const { seedActorLabel, loadActor } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    expect(seedActorLabel(HOME).label).toBe("Rico");
+    expect(loadActor(HOME).label).toBe("Rico");
+  });
+
+  test("never overwrites a label the user already chose", async () => {
+    writeSettings("Rico");
+    const { seedActorLabel, setActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    setActorLabel("chosen", HOME);
+    expect(seedActorLabel(HOME).label).toBe("chosen");
+  });
+
+  test("does NOT adopt the settings placeholder 'User' as a name", async () => {
+    writeSettings("User");
+    const { seedActorLabel, defaultActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    const actor = seedActorLabel(HOME);
+    expect(actor.label).toBe(defaultActorLabel(actor.id));
+  });
+
+  test("leaves the default in place when no name is configured", async () => {
+    writeSettings(undefined);
+    const { seedActorLabel, defaultActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    const actor = seedActorLabel(HOME);
+    expect(actor.label).toBe(defaultActorLabel(actor.id));
+  });
+
+  test("rejects the 'User' placeholder even when it arrives padded", async () => {
+    writeSettings("  User  ");
+    const { seedActorLabel, defaultActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    const actor = seedActorLabel(HOME);
+    expect(actor.label).toBe(defaultActorLabel(actor.id));
+  });
+
+  test("trims a padded name rather than labelling the actor with whitespace", async () => {
+    writeSettings("  Rico  ");
+    const { seedActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    expect(seedActorLabel(HOME).label).toBe("Rico");
+  });
+
+  test("is idempotent — a second run changes nothing", async () => {
+    writeSettings("Rico");
+    const { seedActorLabel } = await actorLib();
+    const { reload } = await import("../src/hooks/lib/settings");
+    reload();
+    const first = seedActorLabel(HOME);
+    const second = seedActorLabel(HOME);
+    expect(second.label).toBe("Rico");
+    expect(second.id).toBe(first.id);
+  });
+});
+
+describe("pal cli actor / machine", () => {
+  async function run(subject: "actor" | "machine", args: string[]) {
+    const { runIdentity } = await import("../src/cli/identity");
+    return runIdentity(subject, args);
+  }
+
+  test("shows the current identity with no arguments", async () => {
+    expect(await run("actor", [])).toBe(0);
+    expect(await run("machine", [])).toBe(0);
+  });
+
+  test("label renames the actor and registers the new label", async () => {
+    expect(await run("actor", ["label", "Rico"])).toBe(0);
+    const { loadActor, readActorRegistry } = await actorLib();
+    expect(loadActor(HOME).label).toBe("Rico");
+    expect(readActorRegistry().map((e) => e.label)).toContain("Rico");
+  });
+
+  test("label renames the machine and registers the new label", async () => {
+    expect(await run("machine", ["label", "workstation"])).toBe(0);
+    const { loadMachine, readRegistry } = await import("../src/hooks/lib/machine");
+    expect(loadMachine(HOME).label).toBe("workstation");
+    expect(readRegistry().map((e) => e.label)).toContain("workstation");
+  });
+
+  test("joins a multi-word name rather than taking only the first token", async () => {
+    expect(await run("actor", ["label", "Rico", "K"])).toBe(0);
+    const { loadActor } = await actorLib();
+    expect(loadActor(HOME).label).toBe("Rico K");
+  });
+
+  test("renaming does not change the id, so existing records still resolve", async () => {
+    const { loadActor } = await actorLib();
+    const before = loadActor(HOME).id;
+    await run("actor", ["label", "Rico"]);
+    expect(loadActor(HOME).id).toBe(before);
+  });
+
+  test("a blank name is refused instead of clearing the label", async () => {
+    expect(await run("actor", ["label", "   "])).toBe(1);
+    const { loadActor, defaultActorLabel } = await actorLib();
+    const actor = loadActor(HOME);
+    expect(actor.label).toBe(defaultActorLabel(actor.id));
+  });
+
+  test("renaming to the current name is idempotent, not an error", async () => {
+    expect(await run("actor", ["label", "Rico"])).toBe(0);
+    expect(await run("actor", ["label", "Rico"])).toBe(0);
+    const { loadActor } = await actorLib();
+    expect(loadActor(HOME).label).toBe("Rico");
+  });
+
+  test("a missing name is refused", async () => {
+    expect(await run("actor", ["label"])).toBe(1);
+  });
+
+  test("an unknown action is refused", async () => {
+    expect(await run("actor", ["rename", "Rico"])).toBe(1);
+    expect(await run("machine", ["delete"])).toBe(1);
+  });
+});

--- a/test/cli-identity.test.ts
+++ b/test/cli-identity.test.ts
@@ -31,16 +31,16 @@ async function actorLib() {
 
 describe("seedActorLabel", () => {
   test("adopts the principal's name while the label is still the default", async () => {
-    writeSettings("Rico");
+    writeSettings("Ada");
     const { seedActorLabel, loadActor } = await actorLib();
     const { reload } = await import("../src/hooks/lib/settings");
     reload();
-    expect(seedActorLabel(HOME).label).toBe("Rico");
-    expect(loadActor(HOME).label).toBe("Rico");
+    expect(seedActorLabel(HOME).label).toBe("Ada");
+    expect(loadActor(HOME).label).toBe("Ada");
   });
 
   test("never overwrites a label the user already chose", async () => {
-    writeSettings("Rico");
+    writeSettings("Ada");
     const { seedActorLabel, setActorLabel } = await actorLib();
     const { reload } = await import("../src/hooks/lib/settings");
     reload();
@@ -76,21 +76,21 @@ describe("seedActorLabel", () => {
   });
 
   test("trims a padded name rather than labelling the actor with whitespace", async () => {
-    writeSettings("  Rico  ");
+    writeSettings("  Ada  ");
     const { seedActorLabel } = await actorLib();
     const { reload } = await import("../src/hooks/lib/settings");
     reload();
-    expect(seedActorLabel(HOME).label).toBe("Rico");
+    expect(seedActorLabel(HOME).label).toBe("Ada");
   });
 
   test("is idempotent — a second run changes nothing", async () => {
-    writeSettings("Rico");
+    writeSettings("Ada");
     const { seedActorLabel } = await actorLib();
     const { reload } = await import("../src/hooks/lib/settings");
     reload();
     const first = seedActorLabel(HOME);
     const second = seedActorLabel(HOME);
-    expect(second.label).toBe("Rico");
+    expect(second.label).toBe("Ada");
     expect(second.id).toBe(first.id);
   });
 });
@@ -107,10 +107,10 @@ describe("pal cli actor / machine", () => {
   });
 
   test("label renames the actor and registers the new label", async () => {
-    expect(await run("actor", ["label", "Rico"])).toBe(0);
+    expect(await run("actor", ["label", "Ada"])).toBe(0);
     const { loadActor, readActorRegistry } = await actorLib();
-    expect(loadActor(HOME).label).toBe("Rico");
-    expect(readActorRegistry().map((e) => e.label)).toContain("Rico");
+    expect(loadActor(HOME).label).toBe("Ada");
+    expect(readActorRegistry().map((e) => e.label)).toContain("Ada");
   });
 
   test("label renames the machine and registers the new label", async () => {
@@ -121,15 +121,15 @@ describe("pal cli actor / machine", () => {
   });
 
   test("joins a multi-word name rather than taking only the first token", async () => {
-    expect(await run("actor", ["label", "Rico", "K"])).toBe(0);
+    expect(await run("actor", ["label", "Ada", "L"])).toBe(0);
     const { loadActor } = await actorLib();
-    expect(loadActor(HOME).label).toBe("Rico K");
+    expect(loadActor(HOME).label).toBe("Ada L");
   });
 
   test("renaming does not change the id, so existing records still resolve", async () => {
     const { loadActor } = await actorLib();
     const before = loadActor(HOME).id;
-    await run("actor", ["label", "Rico"]);
+    await run("actor", ["label", "Ada"]);
     expect(loadActor(HOME).id).toBe(before);
   });
 
@@ -141,10 +141,10 @@ describe("pal cli actor / machine", () => {
   });
 
   test("renaming to the current name is idempotent, not an error", async () => {
-    expect(await run("actor", ["label", "Rico"])).toBe(0);
-    expect(await run("actor", ["label", "Rico"])).toBe(0);
+    expect(await run("actor", ["label", "Ada"])).toBe(0);
+    expect(await run("actor", ["label", "Ada"])).toBe(0);
     const { loadActor } = await actorLib();
-    expect(loadActor(HOME).label).toBe("Rico");
+    expect(loadActor(HOME).label).toBe("Ada");
   });
 
   test("a missing name is refused", async () => {
@@ -152,7 +152,7 @@ describe("pal cli actor / machine", () => {
   });
 
   test("an unknown action is refused", async () => {
-    expect(await run("actor", ["rename", "Rico"])).toBe(1);
+    expect(await run("actor", ["rename", "Ada"])).toBe(1);
     expect(await run("machine", ["delete"])).toBe(1);
   });
 });

--- a/test/emit.test.ts
+++ b/test/emit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import { emit } from "../src/tools/lib/emit";
 
 // emit gates ok()/note() on verbosity (TTY or PAL_VERBOSE), never data().
@@ -81,5 +82,59 @@ describe("emit.ok", () => {
     process.env.PAL_QUIET = "1";
     emit.ok("done");
     expect(captured).toEqual([]);
+  });
+});
+
+describe("emit.receipt", () => {
+  const originalHome = process.env.PAL_HOME;
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.PAL_HOME;
+    else process.env.PAL_HOME = originalHome;
+  });
+
+  function receipt(): Record<string, unknown> {
+    return JSON.parse(captured.join(""));
+  }
+
+  test("is NEVER gated — a write confirms itself even piped and quiet", () => {
+    setTTY(undefined);
+    process.env.PAL_QUIET = "1";
+    process.env.PAL_HOME = "/tmp/pal-home";
+    emit.receipt("/tmp/pal-home/memory/state/threads.jsonl");
+    expect(receipt()).toEqual({ ok: true, wrote: "memory/state/threads.jsonl" });
+  });
+
+  test("reports the path relative to PAL_HOME, not an absolute home path", () => {
+    setTTY(undefined);
+    process.env.PAL_HOME = "/tmp/pal-home";
+    emit.receipt(resolve("/tmp/pal-home", "memory", "actor.json"));
+    expect(receipt().wrote).toBe("memory/actor.json");
+  });
+
+  test("keeps the full path for a file outside PAL_HOME", () => {
+    setTTY(undefined);
+    process.env.PAL_HOME = "/tmp/pal-home";
+    emit.receipt("/var/log/elsewhere.jsonl");
+    expect(receipt().wrote).toBe("/var/log/elsewhere.jsonl");
+  });
+
+  test("merges the operation's own fields into the receipt", () => {
+    setTTY(undefined);
+    process.env.PAL_HOME = "/tmp/pal-home";
+    emit.receipt("/tmp/pal-home/notes.md", { written: 2, deduped: 1 });
+    expect(receipt()).toEqual({
+      ok: true,
+      wrote: "notes.md",
+      written: 2,
+      deduped: 1,
+    });
+  });
+
+  test("emits exactly one line, so a caller can parse it whole", () => {
+    setTTY(undefined);
+    process.env.PAL_HOME = "/tmp/pal-home";
+    emit.receipt("/tmp/pal-home/notes.md", { written: 2 });
+    expect(captured.join("").trimEnd().split("\n").length).toBe(1);
   });
 });

--- a/test/migrate-attribution.test.ts
+++ b/test/migrate-attribution.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+// v5 renames the origin stamp `m` to `machine` on stored records. Nothing ever
+// read `m`, so the risk is not a broken consumer — it is a half-migrated file,
+// which is why every case below checks what the untouched lines look like after.
+
+let HOME: string;
+
+function writeJsonl(relPath: string, lines: string[]): string {
+  const file = resolve(HOME, relPath);
+  mkdirSync(resolve(file, ".."), { recursive: true });
+  writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
+  return file;
+}
+
+function readLines(file: string): Record<string, unknown>[] {
+  return readFileSync(file, "utf-8")
+    .trim()
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+beforeEach(() => {
+  HOME = mkdtempSync(resolve(tmpdir(), "pal-migrate-attr-"));
+  process.env.PAL_HOME = HOME;
+});
+
+afterEach(() => {
+  delete process.env.PAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+async function migration() {
+  const { checkPendingMigrations, runMigrate } = await import("../src/cli/migrate");
+  return { pendingMigrations: checkPendingMigrations, runMigrate };
+}
+
+describe("v5-attribution-keys", () => {
+  test("is pending when a record still stamps origin as m", async () => {
+    writeJsonl("memory/state/threads.jsonl", [JSON.stringify({ id: "t1", m: "mach-1" })]);
+    const { pendingMigrations } = await migration();
+    expect(pendingMigrations().map((p) => p.id)).toContain("v5-attribution-keys");
+  });
+
+  test("is NOT pending once records use machine", async () => {
+    writeJsonl("memory/state/threads.jsonl", [
+      JSON.stringify({ id: "t1", machine: "mach-1" }),
+    ]);
+    const { pendingMigrations } = await migration();
+    expect(pendingMigrations().map((p) => p.id)).not.toContain("v5-attribution-keys");
+  });
+
+  test("renames m to machine while preserving every other field", async () => {
+    const file = writeJsonl("memory/state/threads.jsonl", [
+      JSON.stringify({ id: "t1", m: "mach-1", title: "keep me", status: "open" }),
+    ]);
+    const { runMigrate } = await migration();
+    runMigrate([]);
+    const [record] = readLines(file);
+    expect(record.machine).toBe("mach-1");
+    expect(record.m).toBeUndefined();
+    expect(record.title).toBe("keep me");
+    expect(record.status).toBe("open");
+  });
+
+  test("migrates reflections and every signals jsonl, not just threads", async () => {
+    const reflections = writeJsonl(
+      "memory/learning/reflections/algorithm-reflections.jsonl",
+      [JSON.stringify({ task: "x", m: "mach-1" })]
+    );
+    const ratings = writeJsonl("memory/signals/ratings.jsonl", [
+      JSON.stringify({ type: "rating", m: "mach-1" }),
+    ]);
+    const { runMigrate } = await migration();
+    runMigrate([]);
+    expect(readLines(reflections)[0].machine).toBe("mach-1");
+    expect(readLines(ratings)[0].machine).toBe("mach-1");
+  });
+
+  test("leaves a malformed line exactly as found instead of dropping it", async () => {
+    const file = writeJsonl("memory/state/threads.jsonl", [
+      "not json at all",
+      JSON.stringify({ id: "t1", m: "mach-1" }),
+    ]);
+    const { runMigrate } = await migration();
+    runMigrate([]);
+    const [malformed, migrated] = readFileSync(file, "utf-8").trim().split("\n");
+    expect(malformed).toBe("not json at all");
+    expect(JSON.parse(migrated).machine).toBe("mach-1");
+  });
+
+  test("keeps an existing machine field and still drops the stale m", async () => {
+    const file = writeJsonl("memory/state/threads.jsonl", [
+      JSON.stringify({ id: "t1", m: "old", machine: "authoritative" }),
+    ]);
+    const { runMigrate } = await migration();
+    runMigrate([]);
+    expect(readLines(file)[0].machine).toBe("authoritative");
+    expect(readLines(file)[0].m).toBeUndefined();
+  });
+
+  test("is idempotent — a second run changes nothing", async () => {
+    const file = writeJsonl("memory/state/threads.jsonl", [
+      JSON.stringify({ id: "t1", m: "mach-1" }),
+    ]);
+    const { runMigrate, pendingMigrations } = await migration();
+    runMigrate([]);
+    const after = readFileSync(file, "utf-8");
+    runMigrate([]);
+    expect(readFileSync(file, "utf-8")).toBe(after);
+    expect(pendingMigrations().map((p) => p.id)).not.toContain("v5-attribution-keys");
+  });
+
+  test("--dry-run reports without touching the file", async () => {
+    const file = writeJsonl("memory/state/threads.jsonl", [
+      JSON.stringify({ id: "t1", m: "mach-1" }),
+    ]);
+    const before = readFileSync(file, "utf-8");
+    const { runMigrate } = await migration();
+    runMigrate(["--dry-run"]);
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
+
+  test("is not pending when no record files exist at all", async () => {
+    expect(existsSync(resolve(HOME, "memory", "state", "threads.jsonl"))).toBe(false);
+    const { pendingMigrations } = await migration();
+    expect(pendingMigrations().map((p) => p.id)).not.toContain("v5-attribution-keys");
+  });
+});

--- a/test/relationship-append.test.ts
+++ b/test/relationship-append.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+// appendNotes deduplicates against what today's file already holds, so the count
+// it was handed is not the count that landed. The receipt reports the truth, which
+// is only possible if appendNotes returns it.
+
+let HOME: string;
+
+beforeEach(() => {
+  HOME = mkdtempSync(resolve(tmpdir(), "pal-rel-"));
+  process.env.PAL_HOME = HOME;
+});
+
+afterEach(() => {
+  delete process.env.PAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+async function lib() {
+  return await import("../src/hooks/lib/relationship");
+}
+
+describe("appendNotes reports what actually landed", () => {
+  test("returns the file it wrote and the number written", async () => {
+    const { appendNotes } = await lib();
+    const result = appendNotes([{ type: "W", text: "a world fact" }]);
+    expect(result.written).toBe(1);
+    expect(result.file).toContain("relationship");
+    expect(result.file.endsWith(".md")).toBe(true);
+  });
+
+  test("counts only fresh notes when a duplicate is dropped", async () => {
+    const { appendNotes } = await lib();
+    appendNotes([{ type: "W", text: "same fact" }]);
+    const second = appendNotes([
+      { type: "W", text: "same fact" },
+      { type: "W", text: "a new fact" },
+    ]);
+    expect(second.written).toBe(1);
+  });
+
+  test("returns written 0 when every note is a duplicate", async () => {
+    const { appendNotes } = await lib();
+    appendNotes([{ type: "W", text: "only fact" }]);
+    expect(appendNotes([{ type: "W", text: "only fact" }]).written).toBe(0);
+  });
+
+  test("returns written 0 for an empty batch, still naming the file", async () => {
+    const { appendNotes } = await lib();
+    const result = appendNotes([]);
+    expect(result.written).toBe(0);
+    expect(result.file.endsWith(".md")).toBe(true);
+  });
+});

--- a/test/signals.test.ts
+++ b/test/signals.test.ts
@@ -60,7 +60,7 @@ describe("emitSignal — origin stamp", () => {
     const machineFile = JSON.parse(
       readFileSync(resolve(TEST_HOME, "machine.json"), "utf-8")
     );
-    expect(entry.m).toBe(machineFile.id);
+    expect(entry.machine).toBe(machineFile.id);
   });
 
   test("stamps the SAME id across multiple signals in one session", () => {
@@ -72,7 +72,7 @@ describe("emitSignal — origin stamp", () => {
       .trim()
       .split("\n")
       .map((l) => JSON.parse(l));
-    expect(lines[0].m).toBe(lines[1].m);
-    expect(lines[0].m.length).toBeGreaterThan(0);
+    expect(lines[0].machine).toBe(lines[1].machine);
+    expect(lines[0].machine.length).toBeGreaterThan(0);
   });
 });

--- a/test/thread-build.test.ts
+++ b/test/thread-build.test.ts
@@ -24,7 +24,7 @@ describe("addThread", () => {
     const { addThread } = await lib();
     const t = addThread("a title", "some context");
     const machineFile = JSON.parse(readFileSync(resolve(HOME, "machine.json"), "utf-8"));
-    expect(t.m).toBe(machineFile.id);
+    expect(t.machine).toBe(machineFile.id);
   });
 
   test("anchors the cwd when it falls inside a registered project", async () => {
@@ -55,7 +55,7 @@ describe("addThread", () => {
       .map((l) => JSON.parse(l));
     expect(lines).toHaveLength(1);
     expect(lines[0].id).toBe(t.id);
-    expect(lines[0].m).toBe(t.m);
+    expect(lines[0].machine).toBe(t.machine);
   });
 
   test("starts a new thread as open with no resolved timestamp", async () => {


### PR DESCRIPTION
Closes three tickets on the way to the action ledger: an actor identity that records *who* caused a record, a CLI surface for naming both identities, and an ungated receipt on every tool that writes.

## Actor identity (ISC-4)

A record knew which install wrote it, not which person caused it. `src/hooks/lib/actor.ts` adds an actor id, the agent runtime they were driving, and whether a human turn was behind the call. `currentAttribution()` returns the stamp `{machine, actor, runtime, authority}`; signals, threads and algorithm reflections spread it where they stamped a machine id alone. The keys are spelled out on purpose — an abbreviated stamp is unreadable in a record you open months later, and `pal cli migrate` (`v5-attribution-keys`) rewrites records already carrying the short `m`.

The design turns on one asymmetry:

| | machine.json | memory/actor.json |
|---|---|---|
| Lives at | PAL_HOME root | inside `memory/` |
| Crosses an export | never — on the import denylist | yes, by design |
| Why | two installs sharing an id breaks every origin-scoped read | one person on two machines is one actor |

Because `actor.json` sits inside the exported tree, the existing merge policy handles the rest with no new import code: an install with no actor adopts the incoming one, an install that already has one keeps it.

The storage mechanics were identical for both subjects, so they move to `identity-store.ts` and `machine.ts` becomes an adapter over it. Its 38 existing tests pass unmodified, which is what makes the extraction safe.

## Identity labels (ISC-7)

`init` already asks for the principal's name, so nothing new is prompted — install adopts that name as the actor label while the label is still the generated default. Seeding runs at install rather than at mint, so an actor created before the name was known picks it up too. A chosen label is never overwritten, and the settings placeholder `"User"` names nobody and is not adopted.

Adds `pal cli actor [label <name>]` and `pal cli machine [label <name>]`. Renaming touches no stored record — both subjects resolve labels on read.

No email is collected. The actor id is already the unique key and the label is display only, while `memory/actors/<id>.md` rides in every export — the same reasoning that keeps the hostname out of a machine label.

## Receipt contract (ISC-2, rewritten)

`emit.ok()` is TTY-gated, so a tool confirming a write through it said nothing when an agent ran it over a pipe. The caller then re-read the file to learn what landed, costing more context than the line the gate saved. A write's confirmation is payload, not progress chatter.

`emit.receipt()` emits one ungated JSON line naming the PAL_HOME-relative path plus what the operation produced:

```
{"ok":true,"wrote":"memory/relationship/2026-09/2026-09-04.md","written":1,"deduped":1}
```

`project.ts` already returned a receipt on every mutation; this applies the same contract to the four tools that skipped it.

**Making the receipt true surfaced two writers reporting their input rather than their result.** `appendNotes` silently drops duplicates and `writeHandoffs` trims to the last 20 entries, so both could claim more than landed. Both now return what actually landed — the example above is a 2-note batch where one was a duplicate; the old message said "Relationship note written (2)".

Enforced by a new `no-silent-write` klint rule: a tool that writes to disk and confirms it only via `emit.ok()` fails the gate.

## Verification

- 1298 tests, 0 fail (+50 on this branch)
- All gates green: check, type-check, knip, jscpd, klint, madge, lf, secretlint
- Mutation ratchet 94.19 against a break threshold of 57; remaining survivors are equivalent mutants (Windows path separators unreachable on Linux, one redundant early return)
- The klint rule was proven by planting a silent writer, watching it fire, and clearing it with a receipt
- `pal cli actor` / `machine` exercised end to end against a sandbox `PAL_HOME`

## Notes for review

- ISC-3's ledger should reuse `currentAttribution()` rather than defining its own origin fields.
- ISC-3 claims to subsume ISC-2. It no longer does: a receipt tells the *caller* what landed, a ledger tells an *auditor*. Worth trimming that line when the ledger is picked up.
- The three converted tools stay on the no-coverage ratchet in `stryker.config.mjs` — this PR adds in-process tests for `emit.ts` and `relationship.ts`, not for the tool entrypoints themselves.

Co-authored by [Jarvis](https://github.com/kovrichard/portable-agent-layer)

