### PR TITLE
Query the action ledger by project, window and actor: pal cli ledger log/show/stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ pal cli status        # check your setup
 | `pal cli actor [label <name>]` | Show or rename the actor — who caused a record. Travels with an export, so a shared memory can tell two people apart |
 | `pal cli machine [label <name>]` | Show or rename this install — where a record was written. Never leaves the machine |
 | `pal cli knowledge` | Query & manage the knowledge store (search, graph, stats, hubs, find, show, add, ls, ingest) |
+| `pal cli ledger` | Query the action ledger — `log`, `show <id>`, `stats`, filtered by `--project`, `--since`, `--actor`, `--machine`, `--runtime`, `--outcome`, `--tool`, `--target` |
 | `pal cli skill link <name>` | Link a personal `~/.pal/skills/<name>/` into every installed agent so it is discoverable |
 | `pal cli skill doctor <name>` | Evaluate a skill against the authoring best practices (folder/file-name match, name, description, body length, point-of-view, reference depth) |
 | `pal cli subagent link <name>` | Install a personal `~/.pal/agents/<name>.md` (merged multi-platform definition) into every installed agent, split per platform |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@
  *   status                            Show current PAL configuration
  *   doctor                            Check prerequisites and system health
  *   usage                             Summarize token usage and cost
+ *   ledger <sub> [filters]            Query the action ledger (log · show · stats)
  *   skill link <name>                 Link a personal ~/.pal/skills/<name>/ into installed agents
  *   skill doctor <name|--all>         Evaluate one skill, or every installed skill, against the authoring best practices
  *   subagent link <name>             Install a personal ~/.pal/agents/<name>.md into installed agents
@@ -232,6 +233,12 @@ async function runCli(command: string | undefined, args: string[]) {
       if (code !== 0) process.exit(code);
       break;
     }
+    case "ledger": {
+      const { runLedger } = await import("./ledger");
+      const code = await runLedger(args);
+      if (code !== 0) process.exit(code);
+      break;
+    }
     case "subagent": {
       const { runSubagent } = await import("./subagent");
       const code = await runSubagent(args);
@@ -299,6 +306,8 @@ function showHelp() {
     pal cli machine [label <name>]          Show or rename this install (where it was written)
     pal cli knowledge <sub> [args]          Query & manage the knowledge store
                                             (search · graph · stats · hubs · find · show · add · ls)
+    pal cli ledger <sub> [filters]          Query the action ledger (log · show · stats)
+                                            e.g. ledger log --project X --since 7d
     pal cli skill link <name>               Link a personal ~/.pal/skills/<name>/ into installed agents
     pal cli skill doctor <name|--all>       Evaluate one skill, or every installed skill
     pal cli skill author-model              Print the flagship model that authors skills for the active agent

--- a/src/cli/ledger.ts
+++ b/src/cli/ledger.ts
@@ -14,6 +14,8 @@
 import { parseArgs } from "node:util";
 import type { LedgerEntry } from "../hooks/lib/ledger";
 import {
+  type ChainVerdict,
+  chainVerdict,
   changeShape,
   findEntry,
   type LedgerFilter,
@@ -203,6 +205,17 @@ function describeStanding(verdict: Standing): string {
   }
 }
 
+function describeChain(verdict: ChainVerdict): string {
+  switch (verdict.state) {
+    case "latest":
+      return "the newest recorded action on this target";
+    case "undone":
+      return `undone by ${verdict.by} at ${verdict.at}, which put the file back as this one found it`;
+    default:
+      return `changed again by ${verdict.by} at ${verdict.at}`;
+  }
+}
+
 const UNKEPT_CHANGE: Record<string, string> = {
   redacted: "contents withheld — the target is one the ledger never keeps",
   truncated: "the change was too large to keep; its size and hashes remain",
@@ -231,7 +244,12 @@ function cmdShow(args: string[]): number {
   if (rest.includes("--json")) {
     console.log(
       JSON.stringify(
-        { ...entry, resolved: locate(entry), standing: standing(entry) },
+        {
+          ...entry,
+          resolved: locate(entry),
+          standing: standing(entry),
+          chain: chainVerdict(entry),
+        },
         null,
         2
       )
@@ -249,6 +267,7 @@ function cmdShow(args: string[]): number {
   machine     ${entry.machine}
   size        ${sizeOf(entry.before, "created")} → ${sizeOf(entry.after, "nothing landed")}
   standing    ${describeStanding(standing(entry))}
+  in ledger   ${describeChain(chainVerdict(entry))}
 
   change`);
   printChange(entry);

--- a/src/cli/ledger.ts
+++ b/src/cli/ledger.ts
@@ -1,0 +1,310 @@
+/**
+ * pal cli ledger — query the action ledger.
+ *
+ * Thin presentation layer over src/tools/ledger/query.ts. Owns formatting and
+ * argv parsing only; every question about the records themselves is answered
+ * there.
+ *
+ * Subcommands:
+ *   log [filters]     Matching actions, oldest first
+ *   show <id>         One action in full, with its change and current standing
+ *   stats [filters]   Counts by outcome, runtime, actor, tool and target
+ */
+
+import { parseArgs } from "node:util";
+import type { LedgerEntry } from "../hooks/lib/ledger";
+import {
+  changeShape,
+  findEntry,
+  type LedgerFilter,
+  ledgerFiles,
+  locate,
+  parseSince,
+  queryLedger,
+  type Standing,
+  standing,
+  summarize,
+} from "../tools/ledger/query";
+
+const FILTER_OPTIONS = {
+  project: { type: "string" },
+  since: { type: "string" },
+  until: { type: "string" },
+  actor: { type: "string" },
+  machine: { type: "string" },
+  runtime: { type: "string" },
+  outcome: { type: "string" },
+  tool: { type: "string" },
+  target: { type: "string" },
+  limit: { type: "string" },
+  json: { type: "boolean" },
+} as const;
+
+export async function runLedger(args: string[]): Promise<number> {
+  const [sub, ...rest] = args;
+  switch (sub) {
+    case "log":
+      return cmdLog(rest);
+    case "show":
+      return cmdShow(rest);
+    case "stats":
+      return cmdStats(rest);
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      showHelp();
+      return 0;
+    default:
+      console.error(`Unknown subcommand: ${sub}\n`);
+      showHelp();
+      return 1;
+  }
+}
+
+function showHelp(): void {
+  console.log(`
+  Usage:
+    pal cli ledger <subcommand> [filters]
+
+  Subcommands:
+    log [filters]              Matching actions, oldest first
+    show <id>                  One action in full: change, target, standing
+    stats [filters]            Counts by outcome, runtime, actor, tool, target
+
+  Filters:
+    --project <slug>           Actions against a registered project
+    --since <7d|2026-09-01>    A duration back from now, or a date
+    --until <date>             Upper bound on the timestamp
+    --actor <id>               Who caused it
+    --machine <id>             Which install wrote it
+    --runtime <agent>          claude, cursor, codex, copilot, opencode
+    --outcome <applied|failed|denied>
+    --tool <Edit|Write>
+    --target <substring>       Match anywhere in the recorded path
+    --limit <n>                Keep the newest n matches
+    --json                     Machine-readable output
+
+  Examples:
+    pal cli ledger log --project portable-agent-layer --since 7d
+    pal cli ledger log --target memory/ --outcome applied
+    pal cli ledger stats --since 24h
+`);
+}
+
+/** A filter that silently ignored an unparseable window would answer the wrong question. */
+function buildFilter(values: Record<string, unknown>): LedgerFilter | string {
+  const filter: LedgerFilter = {};
+  for (const key of [
+    "project",
+    "actor",
+    "machine",
+    "runtime",
+    "outcome",
+    "tool",
+    "target",
+  ] as const) {
+    const value = values[key];
+    if (typeof value === "string") filter[key] = value;
+  }
+
+  for (const key of ["since", "until"] as const) {
+    const spec = values[key];
+    if (typeof spec !== "string") continue;
+    const at = parseSince(spec);
+    if (!at) return `Unrecognised --${key}: ${spec} (use 7d, 24h, or a date)`;
+    filter[key] = at;
+  }
+
+  if (typeof values.limit === "string") {
+    const limit = Number(values.limit);
+    if (!Number.isInteger(limit) || limit < 1)
+      return `--limit must be a positive integer`;
+    filter.limit = limit;
+  }
+  return filter;
+}
+
+function parseFilters(args: string[]): { filter: LedgerFilter; json: boolean } | string {
+  try {
+    const { values } = parseArgs({
+      args,
+      options: FILTER_OPTIONS,
+      allowPositionals: true,
+    });
+    const filter = buildFilter(values);
+    return typeof filter === "string" ? filter : { filter, json: values.json === true };
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 11).padEnd(11);
+}
+
+function changedLines(entry: LedgerEntry): string {
+  const shape = changeShape(entry);
+  switch (shape.kind) {
+    case "redacted":
+      return "withheld";
+    case "truncated":
+      return "too large";
+    case "none":
+      return "no change";
+    default: {
+      const added = shape.delta.hunks.reduce((n, h) => n + h.insert.length, 0);
+      const removed = shape.delta.hunks.reduce((n, h) => n + h.remove, 0);
+      return `+${added} -${removed}`;
+    }
+  }
+}
+
+function cmdLog(args: string[]): number {
+  const parsed = parseFilters(args);
+  if (typeof parsed === "string") return fail(parsed);
+
+  const entries = queryLedger(parsed.filter);
+  if (parsed.json) {
+    console.log(JSON.stringify(entries, null, 2));
+    return 0;
+  }
+
+  if (entries.length === 0) {
+    console.log("No actions match.");
+    return 0;
+  }
+
+  for (const entry of entries) {
+    console.log(
+      `${entry.ts}  ${shortId(entry.id)}  ${entry.outcome.padEnd(7)}  ${entry.runtime.padEnd(8)}  ${entry.tool.padEnd(5)}  ${changedLines(entry).padEnd(9)}  ${entry.target}`
+    );
+  }
+  console.log(
+    `\n${entries.length} action(s) across ${ledgerFiles().length} ledger file(s).`
+  );
+  return 0;
+}
+
+function describeStanding(verdict: Standing): string {
+  switch (verdict.state) {
+    case "in-place":
+      return "still in place on disk";
+    case "reverted":
+      return verdict.replays
+        ? "reverted since — the stored change replays cleanly onto the file as it stands"
+        : "reverted since, but the stored change no longer replays";
+    case "superseded":
+      return `superseded — the file has changed again since (now ${verdict.hash.slice(0, 12)})`;
+    case "missing":
+      return "the target no longer exists";
+    default:
+      return verdict.why;
+  }
+}
+
+const UNKEPT_CHANGE: Record<string, string> = {
+  redacted: "contents withheld — the target is one the ledger never keeps",
+  truncated: "the change was too large to keep; its size and hashes remain",
+  none: "no change was recorded, which is what a refused action looks like",
+};
+
+function printChange(entry: LedgerEntry): void {
+  const shape = changeShape(entry);
+  if (shape.kind !== "hunks") {
+    console.log(`  ${UNKEPT_CHANGE[shape.kind]}`);
+    return;
+  }
+  for (const hunk of shape.delta.hunks) {
+    console.log(`  @@ line ${hunk.at + 1}, -${hunk.remove} +${hunk.insert.length}`);
+    for (const line of hunk.insert) console.log(`  + ${line}`);
+  }
+}
+
+function cmdShow(args: string[]): number {
+  const [id, ...rest] = args;
+  if (!id) return fail("Usage: pal cli ledger show <id>");
+
+  const entry = findEntry(id);
+  if (!entry) return fail(`No action with id ${id}`);
+
+  if (rest.includes("--json")) {
+    console.log(
+      JSON.stringify(
+        { ...entry, resolved: locate(entry), standing: standing(entry) },
+        null,
+        2
+      )
+    );
+    return 0;
+  }
+
+  console.log(`
+  ${entry.id}  ${entry.ts}
+  ${entry.tool} → ${outcomeLine(entry)}
+  target      ${entry.target}
+  on disk     ${diskLine(entry)}
+  runtime     ${entry.runtime}, authority ${entry.authority}
+  actor       ${entry.actor}
+  machine     ${entry.machine}
+  size        ${sizeOf(entry.before, "created")} → ${sizeOf(entry.after, "nothing landed")}
+  standing    ${describeStanding(standing(entry))}
+
+  change`);
+  printChange(entry);
+  return 0;
+}
+
+function outcomeLine(entry: LedgerEntry): string {
+  return entry.reason ? `${entry.outcome} (${entry.reason})` : entry.outcome;
+}
+
+function diskLine(entry: LedgerEntry): string {
+  const found = locate(entry);
+  if (found.path) return found.path;
+  return `unresolvable: project ${found.unresolvable} is not registered here`;
+}
+
+function sizeOf(state: LedgerEntry["before"], absent: string): string {
+  return state ? `${state.bytes}b` : absent;
+}
+
+function printTally(label: string, counts: Record<string, number>): void {
+  const rows = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (rows.length === 0) return;
+  console.log(`  ${label}`);
+  for (const [key, count] of rows)
+    console.log(`    ${String(count).padStart(6)}  ${key}`);
+}
+
+function cmdStats(args: string[]): number {
+  const parsed = parseFilters(args);
+  if (typeof parsed === "string") return fail(parsed);
+
+  const stats = summarize(queryLedger(parsed.filter));
+  if (parsed.json) {
+    console.log(JSON.stringify(stats, null, 2));
+    return 0;
+  }
+
+  console.log(
+    `\n  ${stats.total} action(s) across ${ledgerFiles().length} ledger file(s)`
+  );
+  if (stats.span) console.log(`  ${stats.span.first} → ${stats.span.last}\n`);
+  printTally("outcome", stats.byOutcome);
+  printTally("runtime", stats.byRuntime);
+  printTally("tool", stats.byTool);
+  printTally("actor", stats.byActor);
+  if (stats.topTargets.length > 0) {
+    console.log("  most-changed targets");
+    for (const { target, count } of stats.topTargets) {
+      console.log(`    ${String(count).padStart(6)}  ${target}`);
+    }
+  }
+  return 0;
+}
+
+function fail(message: string): number {
+  console.error(message);
+  return 1;
+}

--- a/src/hooks/lib/agent.ts
+++ b/src/hooks/lib/agent.ts
@@ -6,9 +6,10 @@
  * one-shot subscription-backed inference. These helpers identify which agent
  * is currently running PAL so downstream code can dispatch accordingly.
  *
- * Primary signal: PAL_AGENT env var, set by every install template/plugin in
- * `assets/templates/*` and `src/targets/opencode/plugin.ts`. IDE-provided env
- * vars are used as secondary fallbacks for environments that forward them.
+ * Detection reads PAL_AGENT first (set in-process by
+ * `src/targets/opencode/plugin.ts`), then the host's own environment, and only
+ * then the `--agent=` flag the install templates in `assets/templates/*` put
+ * on the hook command line. See declaredAgent for why that order.
  */
 
 export type AgentType = "claude" | "cursor" | "codex" | "copilot" | "opencode" | "vscode";
@@ -42,15 +43,70 @@ function agentFromArgv(): AgentType | undefined {
   return value && KNOWN_AGENTS.has(value as AgentType) ? (value as AgentType) : undefined;
 }
 
+/**
+ * cursor-agent's own session env. CURSOR_VERSION is kept because it costs
+ * nothing and appears on no other surface, but it is not the primary signal —
+ * it is absent from the session env that hook children inherit.
+ */
+function inCursorAgent(): boolean {
+  return Boolean(
+    process.env.CURSOR_AGENT ??
+      process.env.CURSOR_VERSION ??
+      (process.env.CURSOR_INVOKED_AS === "cursor-agent" || undefined)
+  );
+}
+
+function inCodex(): boolean {
+  return Boolean(process.env.CODEX_CLI_VERSION ?? process.env.OPENAI_CODEX);
+}
+
+/**
+ * Set by every Claude Code host — cli, claude-vscode, claude-desktop — and by
+ * none of the others. The Cursor extension carries CURSOR_SPAWN_CHAIN and
+ * friends but no CURSOR_AGENT, so it lands here rather than on cursor.
+ */
+function inClaudeCode(): boolean {
+  return Boolean(process.env.CLAUDE_CODE_ENTRYPOINT);
+}
+
+/**
+ * Which host is running this process, read from what the host itself exported.
+ *
+ * cursor-agent is tested first on purpose: it emulates Claude Code closely
+ * enough to inject CLAUDE_PROJECT_DIR and CLAUDE_CODE_AUTO_COMPACT_WINDOW, so
+ * a CLAUDE_* variable is evidence of Claude Code only once Cursor is ruled out.
+ */
 function agentFromRuntimeEnv(): AgentType | undefined {
-  if (process.env.CURSOR_VERSION) return "cursor";
-  if (process.env.CODEX_CLI_VERSION ?? process.env.OPENAI_CODEX) return "codex";
+  if (inCursorAgent()) return "cursor";
+  if (inCodex()) return "codex";
+  if (inClaudeCode()) return "claude";
   return undefined;
 }
 
-/** The agent something actually said was running, or undefined if nothing did. */
+/**
+ * Cursor and VS Code both load ~/.claude/settings.json alongside their own
+ * config, so a `--agent=claude` flag names a file three hosts share and cannot
+ * by itself say which one is running. Every other flag comes from a config only
+ * its own agent reads.
+ */
+const SHARED_CONFIG_AGENTS: ReadonlySet<AgentType> = new Set(["claude", "vscode"]);
+
+/**
+ * The agent something actually said was running, or undefined if nothing did.
+ *
+ * Host evidence outranks the flag only for the shared config, because one
+ * cursor-agent edit runs both ~/.cursor/hooks.json and ~/.claude/settings.json
+ * and the winner of that race used to decide the recorded runtime. It must not
+ * outrank an unambiguous flag: a Copilot or Codex session started from a Claude
+ * Code terminal inherits CLAUDE_CODE_ENTRYPOINT, and ambient inheritance is
+ * weaker evidence than an agent's own registration.
+ */
 export function declaredAgent(): AgentType | undefined {
-  return agentFromArgv() ?? agentFromEnv() ?? agentFromRuntimeEnv();
+  const explicit = agentFromEnv();
+  if (explicit) return explicit;
+  const flag = agentFromArgv();
+  if (flag && !SHARED_CONFIG_AGENTS.has(flag)) return flag;
+  return agentFromRuntimeEnv() ?? flag;
 }
 
 /** Which agent's conventions to follow. Assumes "claude" when undeclared. */

--- a/src/tools/agent/project.ts
+++ b/src/tools/agent/project.ts
@@ -392,11 +392,36 @@ interface Isc {
   status: IscStatus;
 }
 
+/**
+ * An ISC is one markdown line, so a newline in its text would end the record
+ * and strand every paragraph after it as unparseable debris. Backslashes are
+ * escaped first so that decoding a literal "\n" in a regex cannot be mistaken
+ * for the separator.
+ */
+function encodeIscText(text: string): string {
+  return text
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .replaceAll("\n", "\\n");
+}
+
+const ISC_UNESCAPE: Record<string, string> = { n: "\n", "\\": "\\" };
+
+function decodeIscText(stored: string): string {
+  return stored.replaceAll(/\\(.)/g, (whole, ch) => ISC_UNESCAPE[ch] ?? whole);
+}
+
 function parseIscs(criteria: string): Isc[] {
   const out: Isc[] = [];
   for (const line of criteria.split("\n")) {
     const m = new RegExp(/^-\s+\[( |x|~)\]\s+ISC-(\d+):\s+(.+)$/i).exec(line);
-    if (m) out.push({ id: Number(m[2]), text: m[3].trim(), status: statusFromBox(m[1]) });
+    if (m)
+      out.push({
+        id: Number(m[2]),
+        text: decodeIscText(m[3].trim()),
+        status: statusFromBox(m[1]),
+      });
   }
   return out;
 }
@@ -471,7 +496,7 @@ function cmdAddIsc(args: string[]): void {
   const p = requireProject(name);
   const current = p.criteria ?? "";
   const id = nextIscId(p);
-  const newLine = `- [ ] ISC-${id}: ${title}`;
+  const newLine = `- [ ] ISC-${id}: ${encodeIscText(title)}`;
   p.criteria = current ? `${current.trimEnd()}\n${newLine}` : newLine;
   p.updated = now();
   writeProject(p);
@@ -628,7 +653,7 @@ function cmdEditIsc(args: string[]): void {
       .split("\n")
       .map((l) =>
         new RegExp(String.raw`^-\s+\[[ x~]\]\s+ISC-${id}:`, "i").test(l)
-          ? `- ${box} ISC-${id}: ${text}`
+          ? `- ${box} ISC-${id}: ${encodeIscText(text)}`
           : l
       )
       .join("\n");

--- a/src/tools/ledger/query.ts
+++ b/src/tools/ledger/query.ts
@@ -191,6 +191,50 @@ export function standing(entry: LedgerEntry): Standing {
   return { state: "superseded", hash };
 }
 
+/**
+ * What the record itself says became of a change, as opposed to what the disk
+ * says now.
+ *
+ * `standing` can only describe the present, so any entry that is not the newest
+ * for its target reads as superseded — true, and nearly content-free, since it
+ * says only that something happened afterwards. The ledger already holds the
+ * whole per-target chain, and that answers the question worth asking: whether a
+ * later action put the file back the way this one found it, and which action
+ * that was. It stays true no matter how many edits come after.
+ */
+export type ChainVerdict =
+  | { state: "latest" }
+  | { state: "undone"; by: string; at: string }
+  | { state: "followed"; by: string; at: string };
+
+/**
+ * Deliberately takes no entry list. A chain computed over a filtered query
+ * would report `latest` for an entry the filter merely hid the successor of,
+ * so there is no parameter here through which that mistake can be made.
+ */
+export function chainVerdict(entry: LedgerEntry): ChainVerdict {
+  const all = readLedger();
+  const position = all.findIndex((candidate) => candidate.id === entry.id);
+  const later = all
+    .slice(position + 1)
+    .filter((candidate) => candidate.target === entry.target);
+  if (later.length === 0) return { state: "latest" };
+
+  const undo = undoingEntry(entry, later);
+  const next = undo ?? later[0];
+  return { state: undo ? "undone" : "followed", by: next.id, at: next.ts };
+}
+
+/**
+ * The first later action that left the file as this one found it. An action
+ * that never landed changed nothing to undo, and one that created the file is
+ * undone by a deletion, which this ledger does not record.
+ */
+function undoingEntry(entry: LedgerEntry, later: LedgerEntry[]): LedgerEntry | undefined {
+  if (!entry.before || !entry.after) return undefined;
+  return later.find((candidate) => candidate.after?.hash === entry.before?.hash);
+}
+
 export interface LedgerStats {
   total: number;
   span: { first: string; last: string } | null;

--- a/src/tools/ledger/query.ts
+++ b/src/tools/ledger/query.ts
@@ -1,0 +1,256 @@
+/**
+ * The read side of the action ledger — typed queries over what was recorded.
+ *
+ * The write side stores enough to answer questions, but only in the shape that
+ * was cheap to write: one JSON object per line, targets held as project
+ * anchors, changes held as line deltas. Reading it back with a grep gets the
+ * lines and loses the meaning — a slug is not a path, and a delta is not a
+ * diff until something replays it.
+ *
+ * Every query here spans the archives as well as the active file. Rotation
+ * exists so history survives; a reader that opened only the live file would
+ * quietly answer "what changed" with "what changed recently".
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolveAnchor } from "../../hooks/lib/anchor";
+import {
+  applyDelta,
+  type LedgerDelta,
+  type LedgerEntry,
+  ledgerPath,
+} from "../../hooks/lib/ledger";
+import { paths } from "../../hooks/lib/paths";
+
+const ARCHIVE_RE = /^actions-.*\.jsonl$/;
+
+const ANCHOR_SLUG_RE = /^\{proj:([a-z0-9_-]+)\}/;
+
+export interface LedgerFilter {
+  project?: string;
+  since?: Date;
+  until?: Date;
+  actor?: string;
+  machine?: string;
+  runtime?: string;
+  outcome?: string;
+  tool?: string;
+  target?: string;
+  limit?: number;
+}
+
+/**
+ * Archives first, then the active file, so the result reads oldest to newest
+ * the way the underlying appends do. Names carry an ISO stamp, which sorts
+ * lexicographically into chronological order.
+ */
+export function ledgerFiles(): string[] {
+  const dir = paths.ledger();
+  const archives = readdirSync(dir)
+    .filter((name) => ARCHIVE_RE.test(name))
+    .sort()
+    .map((name) => resolve(dir, name));
+  const active = ledgerPath();
+  return existsSync(active) ? [...archives, active] : archives;
+}
+
+function entriesInFile(file: string): LedgerEntry[] {
+  if (!existsSync(file)) return [];
+  const entries: LedgerEntry[] = [];
+  for (const line of readFileSync(file, "utf-8").split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line) as LedgerEntry);
+    } catch {
+      /* a partially written line is not evidence; skip it */
+    }
+  }
+  return entries;
+}
+
+export function readLedger(): LedgerEntry[] {
+  return ledgerFiles().flatMap(entriesInFile);
+}
+
+export function anchorSlugOf(target: string): string | null {
+  return ANCHOR_SLUG_RE.exec(target)?.[1] ?? null;
+}
+
+/**
+ * An entry names its project two ways depending on when it was written, and a
+ * query has to accept both. An anchored target carries the slug outright. A
+ * plain one predates anchoring or fell outside every registered project, and
+ * only means this project if it resolves under its root on this machine.
+ */
+function inProject(entry: LedgerEntry, slug: string): boolean {
+  const anchored = anchorSlugOf(entry.target);
+  if (anchored) return anchored === slug;
+
+  const root = resolveAnchor(`{proj:${slug}}`);
+  if (root.state !== "anchored") return false;
+  return resolve(entry.target).startsWith(resolve(root.path));
+}
+
+function matchesFilter(entry: LedgerEntry, filter: LedgerFilter): boolean {
+  const at = new Date(entry.ts).getTime();
+  if (filter.since && at < filter.since.getTime()) return false;
+  if (filter.until && at > filter.until.getTime()) return false;
+  if (filter.project && !inProject(entry, filter.project)) return false;
+  if (filter.actor && entry.actor !== filter.actor) return false;
+  if (filter.machine && entry.machine !== filter.machine) return false;
+  if (filter.runtime && entry.runtime !== filter.runtime) return false;
+  if (filter.outcome && entry.outcome !== filter.outcome) return false;
+  if (filter.tool && entry.tool.toLowerCase() !== filter.tool.toLowerCase()) return false;
+  if (filter.target && !entry.target.includes(filter.target)) return false;
+  return true;
+}
+
+/**
+ * Matching entries oldest first, capped from the newest end — a limit that
+ * dropped the newest would answer "the last N changes" with the first ones.
+ */
+export function queryLedger(filter: LedgerFilter = {}): LedgerEntry[] {
+  const matched = readLedger().filter((entry) => matchesFilter(entry, filter));
+  return filter.limit === undefined ? matched : matched.slice(-filter.limit);
+}
+
+export function findEntry(id: string): LedgerEntry | null {
+  return readLedger().find((entry) => entry.id === id) ?? null;
+}
+
+/**
+ * Where the entry's target lives on this machine, or the reason it cannot be
+ * placed — a project this install has never registered resolves to nothing,
+ * and saying so is more useful than printing a slug as if it were a path.
+ */
+export function locate(entry: LedgerEntry): { path?: string; unresolvable?: string } {
+  const resolved = resolveAnchor(entry.target);
+  return resolved.state === "unresolvable"
+    ? { unresolvable: resolved.slug }
+    : { path: resolved.path };
+}
+
+export type ChangeShape =
+  | { kind: "hunks"; delta: LedgerDelta }
+  | { kind: "redacted" }
+  | { kind: "truncated" }
+  | { kind: "none" };
+
+/**
+ * What the entry can say about its own change. The three empty cases are kept
+ * apart because they mean different things: contents deliberately withheld, a
+ * change too large to keep, and an action that never landed at all.
+ */
+export function changeShape(entry: LedgerEntry): ChangeShape {
+  if (!entry.delta) return { kind: "none" };
+  if (entry.delta.redacted) return { kind: "redacted" };
+  if (entry.delta.truncated) return { kind: "truncated" };
+  return { kind: "hunks", delta: entry.delta };
+}
+
+/**
+ * Whether the change this entry recorded is still the state of the file.
+ *
+ * The comparison is against the hashes the entry already carries, not a replay
+ * from a stored before-image — the ledger keeps the change, not the prior file,
+ * so there is nothing to replay from unless the file happens to be sitting at
+ * its before-state again. `reverted` is exactly that case, and there the delta
+ * can be run forward for real, which is why it reports whether it did.
+ */
+export type Standing =
+  | { state: "in-place" }
+  | { state: "reverted"; replays: boolean }
+  | { state: "superseded"; hash: string }
+  | { state: "missing" }
+  | { state: "unknown"; why: string };
+
+function hashOf(content: string): string {
+  return new Bun.CryptoHasher("sha256").update(content, "utf-8").digest("hex");
+}
+
+function replaysToAfter(entry: LedgerEntry, onDisk: string): boolean {
+  if (!entry.delta || !entry.after) return false;
+  const rebuilt = applyDelta(onDisk, entry.delta);
+  return rebuilt !== null && hashOf(rebuilt) === entry.after.hash;
+}
+
+export function standing(entry: LedgerEntry): Standing {
+  if (!entry.after) return { state: "unknown", why: "the action never landed" };
+
+  const found = locate(entry);
+  if (!found.path)
+    return { state: "unknown", why: `unknown project ${found.unresolvable}` };
+  if (!existsSync(found.path)) return { state: "missing" };
+
+  const onDisk = readFileSync(found.path, "utf-8");
+  const hash = hashOf(onDisk);
+  if (hash === entry.after.hash) return { state: "in-place" };
+  if (entry.before && hash === entry.before.hash)
+    return { state: "reverted", replays: replaysToAfter(entry, onDisk) };
+  return { state: "superseded", hash };
+}
+
+export interface LedgerStats {
+  total: number;
+  span: { first: string; last: string } | null;
+  byOutcome: Record<string, number>;
+  byRuntime: Record<string, number>;
+  byActor: Record<string, number>;
+  byTool: Record<string, number>;
+  topTargets: { target: string; count: number }[];
+}
+
+function tally<T>(items: T[], key: (item: T) => string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const k = key(item);
+    counts[k] = (counts[k] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function rank(
+  counts: Record<string, number>,
+  top: number
+): { target: string; count: number }[] {
+  return Object.entries(counts)
+    .map(([target, count]) => ({ target, count }))
+    .sort((a, b) => b.count - a.count || a.target.localeCompare(b.target))
+    .slice(0, top);
+}
+
+export function summarize(entries: LedgerEntry[], topTargets = 10): LedgerStats {
+  const first = entries.at(0);
+  const last = entries.at(-1);
+  return {
+    total: entries.length,
+    span: first && last ? { first: first.ts, last: last.ts } : null,
+    byOutcome: tally(entries, (e) => e.outcome),
+    byRuntime: tally(entries, (e) => e.runtime),
+    byActor: tally(entries, (e) => e.actor),
+    byTool: tally(entries, (e) => e.tool),
+    topTargets: rank(
+      tally(entries, (e) => e.target),
+      topTargets
+    ),
+  };
+}
+
+/**
+ * A window expressed the way someone asks for one: a duration back from now
+ * ("7d", "24h") or a calendar date. Nothing else is guessed at — an
+ * unparseable spec is reported rather than silently treated as no filter,
+ * which would answer a narrow question with the whole ledger.
+ */
+export function parseSince(spec: string, now: Date = new Date()): Date | null {
+  const duration = /^(\d+)([smhdw])$/.exec(spec.trim());
+  if (duration) {
+    const unit = { s: 1e3, m: 6e4, h: 36e5, d: 864e5, w: 6048e5 }[duration[2]];
+    if (!unit) return null;
+    return new Date(now.getTime() - Number(duration[1]) * unit);
+  }
+
+  const at = new Date(spec);
+  return Number.isNaN(at.getTime()) ? null : at;
+}

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -5,11 +5,28 @@ import { resolve } from "node:path";
 
 let HOME: string;
 
+/** Every signal declaredAgent reads; a host var inherited from the session that
+ * runs the suite would declare an agent these cases mean to leave undeclared. */
+const AGENT_SIGNALS = [
+  "PAL_AGENT",
+  "CURSOR_AGENT",
+  "CURSOR_VERSION",
+  "CURSOR_INVOKED_AS",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CODEX_CLI_VERSION",
+  "OPENAI_CODEX",
+] as const;
+
+const savedSignals: Record<string, string | undefined> = {};
+
 beforeEach(async () => {
   HOME = mkdtempSync(resolve(tmpdir(), "pal-actor-"));
   process.env.PAL_HOME = HOME;
   delete process.env.PAL_SPAWNED_INFERENCE;
-  delete process.env.PAL_AGENT;
+  for (const key of AGENT_SIGNALS) {
+    savedSignals[key] = process.env[key];
+    delete process.env[key];
+  }
   // settings caches per process and bun shares one across test files.
   (await import("../src/hooks/lib/settings")).reload();
 });
@@ -17,7 +34,10 @@ beforeEach(async () => {
 afterEach(() => {
   delete process.env.PAL_HOME;
   delete process.env.PAL_SPAWNED_INFERENCE;
-  delete process.env.PAL_AGENT;
+  for (const key of AGENT_SIGNALS) {
+    if (savedSignals[key] === undefined) delete process.env[key];
+    else process.env[key] = savedSignals[key];
+  }
   rmSync(HOME, { recursive: true, force: true });
 });
 

--- a/test/agent-detect.test.ts
+++ b/test/agent-detect.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   blockResponse,
+  declaredAgent,
   getActiveAgent,
   isClaude,
   isCodex,
@@ -13,6 +14,11 @@ import {
 const PRESERVED_ENV_KEYS = [
   "PAL_AGENT",
   "CURSOR_VERSION",
+  "CURSOR_AGENT",
+  "CURSOR_INVOKED_AS",
+  "CURSOR_SPAWN_CHAIN",
+  "CURSOR_SPAWNED_BY_EXTENSION_ID",
+  "CLAUDE_CODE_ENTRYPOINT",
   "CODEX_CLI_VERSION",
   "OPENAI_CODEX",
 ] as const;
@@ -265,10 +271,16 @@ describe("getActiveAgent — --agent= argv flag", () => {
     expect(getActiveAgent()).toBe("vscode");
   });
 
-  test("argv wins over PAL_AGENT, so one file cannot be mislabelled by a stale env", () => {
+  test("PAL_AGENT wins over argv, because argv names the config not the process", () => {
     process.argv = ["bun", "hook.ts", "--agent=vscode"];
     process.env.PAL_AGENT = "copilot";
-    expect(getActiveAgent()).toBe("vscode");
+    expect(getActiveAgent()).toBe("copilot");
+  });
+
+  test("host evidence wins over argv, so the registration file cannot mislabel", () => {
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    process.env.CURSOR_AGENT = "1";
+    expect(getActiveAgent()).toBe("cursor");
   });
 
   test("falls back to PAL_AGENT when the flag is absent", () => {
@@ -281,6 +293,106 @@ describe("getActiveAgent — --agent= argv flag", () => {
     process.argv = ["bun", "hook.ts", "--agent=bogus"];
     process.env.PAL_AGENT = "copilot";
     expect(getActiveAgent()).toBe("copilot");
+  });
+});
+
+/**
+ * Every environment below is a live `env` dump from a real host, reduced to the
+ * variables detection reads. The argv flag on each case is the one the install
+ * templates actually register, so a case that resolves by argv alone is a case
+ * where the ledger recorded the wrong runtime.
+ */
+describe("getActiveAgent — the four hosts PAL actually runs under", () => {
+  const saved: Record<string, string | undefined> = {};
+  const savedArgv = process.argv;
+
+  beforeEach(() => {
+    for (const k of PRESERVED_ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    process.argv = savedArgv;
+    for (const k of PRESERVED_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test("cursor-agent is cursor even when registered as --agent=claude", () => {
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    process.env.CURSOR_AGENT = "1";
+    process.env.CURSOR_INVOKED_AS = "cursor-agent";
+    expect(getActiveAgent()).toBe("cursor");
+  });
+
+  test("one cursor-agent edit labels both racing hook processes the same", () => {
+    process.env.CURSOR_AGENT = "1";
+    process.argv = ["bun", "hook.ts", "--agent=cursor"];
+    const fromCursorConfig = getActiveAgent();
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    expect(getActiveAgent()).toBe(fromCursorConfig);
+  });
+
+  test("the Claude extension inside Cursor is claude, not cursor", () => {
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    process.env.CLAUDE_CODE_ENTRYPOINT = "claude-vscode";
+    process.env.CURSOR_SPAWN_CHAIN = "anthropic.claude-code";
+    process.env.CURSOR_SPAWNED_BY_EXTENSION_ID = "anthropic.claude-code";
+    expect(declaredAgent()).toBe("claude");
+  });
+
+  test("Claude Desktop is identified, not defaulted to", () => {
+    process.argv = ["bun", "hook.ts"];
+    process.env.CLAUDE_CODE_ENTRYPOINT = "claude-desktop";
+    expect(declaredAgent()).toBe("claude");
+  });
+
+  test("a pal-launched CLI session is identified, not defaulted to", () => {
+    process.argv = ["bun", "hook.ts"];
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+    expect(declaredAgent()).toBe("claude");
+  });
+
+  test("nothing at all stays undeclared rather than claiming a host", () => {
+    process.argv = ["bun", "hook.ts"];
+    expect(declaredAgent()).toBeUndefined();
+    expect(getActiveAgent()).toBe("claude");
+  });
+
+  test("cursor-agent emulating Claude Code still reads as cursor", () => {
+    process.env.CURSOR_AGENT = "1";
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+    expect(getActiveAgent()).toBe("cursor");
+  });
+
+  test("copilot started from a Claude Code terminal keeps its own registration", () => {
+    process.argv = ["bun", "hook.ts", "--agent=copilot"];
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+    expect(getActiveAgent()).toBe("copilot");
+  });
+
+  test("codex started from a Claude Code terminal keeps its own registration", () => {
+    process.argv = ["bun", "hook.ts", "--agent=codex"];
+    process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+    expect(getActiveAgent()).toBe("codex");
+  });
+
+  test("a Cursor spawn chain alone is not evidence of cursor-agent", () => {
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    process.env.CURSOR_SPAWN_CHAIN = "anthropic.claude-code";
+    expect(getActiveAgent()).toBe("claude");
+  });
+
+  test("cursor-agent denies in Cursor's shape despite the claude registration", () => {
+    process.argv = ["bun", "hook.ts", "--agent=claude"];
+    process.env.CURSOR_AGENT = "1";
+    expect(JSON.parse(blockResponse("nope", "PreToolUse"))).toEqual({
+      permission: "deny",
+      user_message: "nope",
+    });
   });
 });
 

--- a/test/ledger-query.test.ts
+++ b/test/ledger-query.test.ts
@@ -333,6 +333,126 @@ describe("whether a recorded change is still the state of the file", () => {
   });
 });
 
+describe("what the record says became of a change", () => {
+  const A = "hash-a";
+  const B = "hash-b";
+  const C = "hash-c";
+
+  function link(id: string, before: string | null, after: string | null): EntryOverrides {
+    return {
+      id,
+      before: before === null ? null : { hash: before, bytes: 1 },
+      after: after === null ? null : { hash: after, bytes: 1 },
+    };
+  }
+
+  async function verdictFor(id: string) {
+    const q = await query();
+    const found = q.findEntry(id);
+    if (!found) throw new Error(`no entry ${id}`);
+    return q.chainVerdict(found);
+  }
+
+  test("the newest action on a target is the latest", async () => {
+    writeLedger("actions.jsonl", [entry(link("only", A, B))]);
+    expect(await verdictFor("only")).toEqual({ state: "latest" });
+  });
+
+  test("a later action restoring the before-state is named as the undo", async () => {
+    writeLedger("actions.jsonl", [
+      entry(link("first", A, B)),
+      entry({ ...link("undo", B, A), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("first")).toEqual({
+      state: "undone",
+      by: "undo",
+      at: "2026-09-04T13:00:00.000Z",
+    });
+  });
+
+  test("a later action that changed it again is followed, not undone", async () => {
+    writeLedger("actions.jsonl", [
+      entry(link("first", A, B)),
+      entry({ ...link("onward", B, C), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("first")).toEqual({
+      state: "followed",
+      by: "onward",
+      at: "2026-09-04T13:00:00.000Z",
+    });
+  });
+
+  /** Naming a later undo would date the revert to the wrong action. */
+  test("the first undo is named, not a later one", async () => {
+    writeLedger("actions.jsonl", [
+      entry(link("first", A, B)),
+      entry({ ...link("undo", B, A), ts: "2026-09-04T13:00:00.000Z" }),
+      entry({ ...link("again", A, B), ts: "2026-09-04T14:00:00.000Z" }),
+      entry({ ...link("undo2", B, A), ts: "2026-09-04T15:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("first")).toMatchObject({ state: "undone", by: "undo" });
+  });
+
+  test("another target's actions are not part of this chain", async () => {
+    writeLedger("actions.jsonl", [
+      entry(link("first", A, B)),
+      entry({
+        ...link("elsewhere", B, A),
+        target: "{proj:demo}/other.ts",
+        ts: "2026-09-04T13:00:00.000Z",
+      }),
+    ]);
+    expect(await verdictFor("first")).toEqual({ state: "latest" });
+  });
+
+  /**
+   * The later action lands on the refused one's before-hash, which is what an
+   * undo looks like — but a refused action changed nothing, so there was
+   * nothing for it to undo.
+   */
+  test("an action that never landed has nothing to undo", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ ...link("denied", A, null), outcome: "denied", delta: undefined }),
+      entry({ ...link("next", B, A), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("denied")).toMatchObject({ state: "followed", by: "next" });
+  });
+
+  test("a file creation is not undone by a later write", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ ...link("created", null, B), tool: "Write" }),
+      entry({ ...link("after", B, C), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("created")).toMatchObject({ state: "followed" });
+  });
+
+  /** Independence from disk is the whole point: it stays true after the file moves on. */
+  test("the verdict holds with no file on disk at all", async () => {
+    writeLedger("actions.jsonl", [
+      entry(link("first", A, B)),
+      entry({ ...link("undo", B, A), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    registerProject("demo", PROJECT);
+
+    const q = await query();
+    const found = q.findEntry("first");
+    if (!found) throw new Error("missing");
+    expect(q.standing(found).state).toBe("missing");
+    expect(q.chainVerdict(found)).toMatchObject({ state: "undone", by: "undo" });
+  });
+
+  /** The chain must span the whole ledger, not whatever a filter left behind. */
+  test("an undo living in a rotated archive is still found", async () => {
+    writeLedger("actions-2026-09-01T00-00-00-000Z.jsonl", [
+      entry(link("archived", A, B)),
+    ]);
+    writeLedger("actions.jsonl", [
+      entry({ ...link("undo", B, A), ts: "2026-09-04T13:00:00.000Z" }),
+    ]);
+    expect(await verdictFor("archived")).toMatchObject({ state: "undone", by: "undo" });
+  });
+});
+
 describe("counts over a set of actions", () => {
   test("groups by every dimension the ledger records", async () => {
     writeLedger("actions.jsonl", [

--- a/test/ledger-query.test.ts
+++ b/test/ledger-query.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+// The read side is only worth as much as the questions it can answer without
+// lying. These cases are about the three ways it could: losing the rotated
+// history, missing entries whose target is spelled the other way, and calling a
+// change "empty" when it was withheld or too large to keep.
+
+let HOME: string;
+let PROJECT: string;
+
+beforeEach(() => {
+  HOME = mkdtempSync(resolve(tmpdir(), "pal-ledger-query-"));
+  PROJECT = mkdtempSync(resolve(tmpdir(), "pal-project-"));
+  process.env.PAL_HOME = HOME;
+  mkdirSync(resolve(HOME, "memory", "ledger"), { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.PAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+  rmSync(PROJECT, { recursive: true, force: true });
+});
+
+async function query() {
+  return await import("../src/tools/ledger/query");
+}
+
+function registerProject(slug: string, path: string): void {
+  const dir = resolve(HOME, "memory", "projects", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    resolve(dir, "ISA.md"),
+    `---\nname: ${slug}\nstatus: active\ncreated: 2026-09-01T00:00:00.000Z\nupdated: 2026-09-01T00:00:00.000Z\npath: ${path}\n---\n\n## Goal\n\nnone\n`,
+    "utf-8"
+  );
+}
+
+type EntryOverrides = Record<string, unknown>;
+
+let serial = 0;
+
+function entry(overrides: EntryOverrides = {}): Record<string, unknown> {
+  serial++;
+  return {
+    id: `id-${serial}`,
+    ts: "2026-09-04T12:00:00.000Z",
+    machine: "machine-a",
+    actor: "actor-a",
+    runtime: "claude",
+    authority: "user",
+    tool: "Edit",
+    target: "{proj:demo}/src/a.ts",
+    outcome: "applied",
+    before: { hash: "before-hash", bytes: 10 },
+    after: { hash: "after-hash", bytes: 12 },
+    delta: { hunks: [{ at: 0, remove: 1, insert: ["new"] }] },
+    ...overrides,
+  };
+}
+
+function writeLedger(name: string, rows: Record<string, unknown>[]): void {
+  writeFileSync(
+    resolve(HOME, "memory", "ledger", name),
+    `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+    "utf-8"
+  );
+}
+
+describe("history that rotation moved aside", () => {
+  test("an archived entry is still found", async () => {
+    writeLedger("actions-2026-09-01T00-00-00-000Z.jsonl", [entry({ id: "old" })]);
+    writeLedger("actions.jsonl", [entry({ id: "current" })]);
+
+    const ids = (await query()).readLedger().map((e) => e.id);
+    expect(ids).toEqual(["old", "current"]);
+  });
+
+  test("archives are read oldest first, so the log reads in order", async () => {
+    writeLedger("actions-2026-09-02T00-00-00-000Z.jsonl", [entry({ id: "second" })]);
+    writeLedger("actions-2026-09-01T00-00-00-000Z.jsonl", [entry({ id: "first" })]);
+
+    expect((await query()).readLedger().map((e) => e.id)).toEqual(["first", "second"]);
+  });
+
+  test("a half-written line is skipped rather than failing the query", async () => {
+    writeFileSync(
+      resolve(HOME, "memory", "ledger", "actions.jsonl"),
+      `${JSON.stringify(entry({ id: "good" }))}\n{"id":"trunc`,
+      "utf-8"
+    );
+    expect((await query()).readLedger().map((e) => e.id)).toEqual(["good"]);
+  });
+
+  test("no ledger at all is an empty result, not a throw", async () => {
+    expect((await query()).readLedger()).toEqual([]);
+  });
+});
+
+describe("naming a project two different ways", () => {
+  test("an anchored target matches its slug", async () => {
+    writeLedger("actions.jsonl", [entry({ id: "anchored" })]);
+    registerProject("demo", PROJECT);
+
+    const hits = (await query()).queryLedger({ project: "demo" });
+    expect(hits.map((e) => e.id)).toEqual(["anchored"]);
+  });
+
+  /** Entries written before anchoring shipped carry an absolute path instead. */
+  test("a plain absolute path inside the project matches too", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ id: "plain", target: resolve(PROJECT, "src", "b.ts") }),
+    ]);
+    registerProject("demo", PROJECT);
+
+    expect((await query()).queryLedger({ project: "demo" }).map((e) => e.id)).toEqual([
+      "plain",
+    ]);
+  });
+
+  test("a path outside the project does not match it", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ id: "elsewhere", target: "/somewhere/else.ts" }),
+    ]);
+    registerProject("demo", PROJECT);
+
+    expect((await query()).queryLedger({ project: "demo" })).toEqual([]);
+  });
+
+  test("another project's anchor does not match", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ id: "other", target: "{proj:other}/src/a.ts" }),
+    ]);
+    registerProject("demo", PROJECT);
+
+    expect((await query()).queryLedger({ project: "demo" })).toEqual([]);
+  });
+});
+
+describe("filters", () => {
+  beforeEach(() => {
+    writeLedger("actions.jsonl", [
+      entry({
+        id: "a",
+        ts: "2026-09-01T00:00:00.000Z",
+        outcome: "applied",
+        tool: "Edit",
+      }),
+      entry({
+        id: "b",
+        ts: "2026-09-03T00:00:00.000Z",
+        outcome: "denied",
+        tool: "Write",
+        runtime: "cursor",
+        actor: "actor-b",
+        machine: "machine-b",
+        after: null,
+        delta: undefined,
+      }),
+      entry({
+        id: "c",
+        ts: "2026-09-05T00:00:00.000Z",
+        target: "{proj:demo}/memory/x.md",
+      }),
+    ]);
+  });
+
+  test("a window keeps only what falls inside it", async () => {
+    const hits = (await query()).queryLedger({
+      since: new Date("2026-09-02T00:00:00.000Z"),
+      until: new Date("2026-09-04T00:00:00.000Z"),
+    });
+    expect(hits.map((e) => e.id)).toEqual(["b"]);
+  });
+
+  test("filters compose rather than replacing one another", async () => {
+    const hits = (await query()).queryLedger({ outcome: "applied", tool: "Edit" });
+    expect(hits.map((e) => e.id)).toEqual(["a", "c"]);
+  });
+
+  test("a target substring answers which actions touched shared memory", async () => {
+    expect((await query()).queryLedger({ target: "memory/" }).map((e) => e.id)).toEqual([
+      "c",
+    ]);
+  });
+
+  test("actor and machine separate one install's actions from another's", async () => {
+    expect(
+      (await query()).queryLedger({ machine: "machine-b" }).map((e) => e.id)
+    ).toEqual(["b"]);
+    expect((await query()).queryLedger({ actor: "actor-b" }).map((e) => e.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  test("a limit keeps the newest, not the first", async () => {
+    expect((await query()).queryLedger({ limit: 1 }).map((e) => e.id)).toEqual(["c"]);
+  });
+
+  test("no filter returns everything", async () => {
+    expect((await query()).queryLedger()).toHaveLength(3);
+  });
+});
+
+describe("a window asked for the way someone says it", () => {
+  const NOW = new Date("2026-09-10T00:00:00.000Z");
+
+  test("a duration counts back from now", async () => {
+    const since = (await query()).parseSince("7d", NOW);
+    expect(since?.toISOString()).toBe("2026-09-03T00:00:00.000Z");
+  });
+
+  test("hours and weeks are understood too", async () => {
+    expect((await query()).parseSince("24h", NOW)?.toISOString()).toBe(
+      "2026-09-09T00:00:00.000Z"
+    );
+    expect((await query()).parseSince("1w", NOW)?.toISOString()).toBe(
+      "2026-09-03T00:00:00.000Z"
+    );
+  });
+
+  test("a calendar date is taken as given", async () => {
+    expect((await query()).parseSince("2026-09-01", NOW)?.toISOString()).toBe(
+      "2026-09-01T00:00:00.000Z"
+    );
+  });
+
+  /** Silently ignoring it would answer a narrow question with the whole ledger. */
+  test("nonsense is rejected instead of ignored", async () => {
+    expect((await query()).parseSince("last tuesday", NOW)).toBeNull();
+    expect((await query()).parseSince("7q", NOW)).toBeNull();
+  });
+});
+
+describe("what an entry can say about its own change", () => {
+  test("hunks are reported as hunks", async () => {
+    writeLedger("actions.jsonl", [entry()]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).changeShape(only).kind).toBe("hunks");
+  });
+
+  test("a withheld change is not an empty one", async () => {
+    writeLedger("actions.jsonl", [entry({ delta: { hunks: [], redacted: true } })]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).changeShape(only).kind).toBe("redacted");
+  });
+
+  test("a change too large to keep is not an empty one either", async () => {
+    writeLedger("actions.jsonl", [entry({ delta: { hunks: [], truncated: true } })]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).changeShape(only).kind).toBe("truncated");
+  });
+
+  test("an action that never landed recorded no change", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ outcome: "denied", after: null, delta: undefined }),
+    ]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).changeShape(only).kind).toBe("none");
+  });
+});
+
+describe("whether a recorded change is still the state of the file", () => {
+  const AFTER = "one\ntwo\n";
+  const BEFORE = "one\n";
+
+  function hash(content: string): string {
+    return new Bun.CryptoHasher("sha256").update(content, "utf-8").digest("hex");
+  }
+
+  function edit(overrides: EntryOverrides = {}): Record<string, unknown> {
+    return entry({
+      target: "{proj:demo}/f.txt",
+      before: { hash: hash(BEFORE), bytes: BEFORE.length },
+      after: { hash: hash(AFTER), bytes: AFTER.length },
+      delta: { hunks: [{ at: 1, remove: 0, insert: ["two"] }] },
+      ...overrides,
+    });
+  }
+
+  function onDisk(content: string): void {
+    writeFileSync(resolve(PROJECT, "f.txt"), content, "utf-8");
+  }
+
+  beforeEach(() => {
+    registerProject("demo", PROJECT);
+  });
+
+  test("a file still matching the after-hash is in place", async () => {
+    writeLedger("actions.jsonl", [edit()]);
+    onDisk(AFTER);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).standing(only).state).toBe("in-place");
+  });
+
+  /** Back at its before-state is the one case the stored delta can be run forward. */
+  test("a file back at its before-hash reads as reverted, and the delta replays", async () => {
+    writeLedger("actions.jsonl", [edit()]);
+    onDisk(BEFORE);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).standing(only)).toEqual({ state: "reverted", replays: true });
+  });
+
+  test("a file that moved on again is superseded, not a mismatch", async () => {
+    writeLedger("actions.jsonl", [edit()]);
+    onDisk("something else entirely\n");
+    const [only] = (await query()).queryLedger();
+    expect((await query()).standing(only).state).toBe("superseded");
+  });
+
+  test("a deleted target is reported as gone", async () => {
+    writeLedger("actions.jsonl", [edit()]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).standing(only).state).toBe("missing");
+  });
+
+  test("an action that never landed has no standing to check", async () => {
+    writeLedger("actions.jsonl", [
+      edit({ outcome: "denied", after: null, delta: undefined }),
+    ]);
+    const [only] = (await query()).queryLedger();
+    expect((await query()).standing(only).state).toBe("unknown");
+  });
+
+  test("a project this install never registered is unknown, not missing", async () => {
+    writeLedger("actions.jsonl", [edit({ target: "{proj:never-seen}/f.txt" })]);
+    const [only] = (await query()).queryLedger();
+    const verdict = (await query()).standing(only);
+    expect(verdict.state).toBe("unknown");
+    expect(verdict).toHaveProperty("why", "unknown project never-seen");
+  });
+});
+
+describe("counts over a set of actions", () => {
+  test("groups by every dimension the ledger records", async () => {
+    writeLedger("actions.jsonl", [
+      entry({ outcome: "applied", runtime: "claude", tool: "Edit" }),
+      entry({ outcome: "denied", runtime: "cursor", tool: "Write", after: null }),
+      entry({ outcome: "applied", runtime: "claude", tool: "Edit" }),
+    ]);
+
+    const q = await query();
+    const stats = q.summarize(q.queryLedger());
+    expect(stats.total).toBe(3);
+    expect(stats.byOutcome).toEqual({ applied: 2, denied: 1 });
+    expect(stats.byRuntime).toEqual({ claude: 2, cursor: 1 });
+    expect(stats.byTool).toEqual({ Edit: 2, Write: 1 });
+    expect(stats.topTargets[0]).toEqual({ target: "{proj:demo}/src/a.ts", count: 3 });
+  });
+
+  test("an empty set has no span to report", async () => {
+    const q = await query();
+    expect(q.summarize([]).span).toBeNull();
+  });
+});

--- a/test/project-cli.test.ts
+++ b/test/project-cli.test.ts
@@ -479,6 +479,62 @@ describe("project CLI", () => {
     expect(section("edit", "Criteria")).not.toContain("vague wording");
   });
 
+  /**
+   * An ISC is one markdown line. Before this was encoded, a paragraph break
+   * ended the record and every paragraph after it was stranded in the file as
+   * unparseable debris — silently, because the command echoed back the text it
+   * had been handed rather than the text it stored.
+   */
+  const MULTI = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+
+  test("add-isc keeps every paragraph of a multi-paragraph ISC", async () => {
+    await runCli(["create", "multi", "--path", "/tmp/multi-fake"]);
+    await runCli(["add-isc", "multi", MULTI]);
+
+    const shown = JSON.parse((await runCli(["show-isc", "multi", "1"])).stdout);
+    expect(shown.text).toBe(MULTI);
+  });
+
+  test("edit-isc keeps every paragraph of a multi-paragraph ISC", async () => {
+    await runCli(["create", "multie", "--path", "/tmp/multie-fake"]);
+    await runCli(["add-isc", "multie", "one line"]);
+    await runCli(["edit-isc", "multie", "1", MULTI]);
+
+    const shown = JSON.parse((await runCli(["show-isc", "multie", "1"])).stdout);
+    expect(shown.text).toBe(MULTI);
+  });
+
+  test("a multi-paragraph ISC still occupies exactly one line in the file", async () => {
+    await runCli(["create", "oneline", "--path", "/tmp/oneline-fake"]);
+    await runCli(["add-isc", "oneline", MULTI]);
+
+    const iscLines = section("oneline", "Criteria")
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    expect(iscLines).toEqual([
+      "- [ ] ISC-1: First paragraph.\\n\\nSecond paragraph.\\n\\nThird paragraph.",
+    ]);
+  });
+
+  test("a literal backslash-n in an ISC is not decoded into a line break", async () => {
+    await runCli(["create", "esc", "--path", "/tmp/esc-fake"]);
+    const withRegex = String.raw`deny pattern: kubectl\s+prod and a literal \n sequence`;
+    await runCli(["add-isc", "esc", withRegex]);
+
+    const shown = JSON.parse((await runCli(["show-isc", "esc", "1"])).stdout);
+    expect(shown.text).toBe(withRegex);
+    expect(shown.text).not.toContain("\n");
+  });
+
+  test("a multi-paragraph ISC survives being completed and shown from the Changelog", async () => {
+    await runCli(["create", "multidone", "--path", "/tmp/multidone-fake"]);
+    await runCli(["add-isc", "multidone", MULTI]);
+    await runCli(["complete-isc", "multidone", "1"]);
+
+    const shown = JSON.parse((await runCli(["show-isc", "multidone", "1"])).stdout);
+    expect(shown.text).toBe(MULTI);
+  });
+
   test("edit-isc keeps a closed ISC closed and in the Changelog", async () => {
     await runCli(["create", "editc", "--path", "/tmp/editc-fake"]);
     await runCli(["add-isc", "editc", "before"]);


### PR DESCRIPTION
Rolling branch for the ledger work that follows PR #5. ISC-3 (the write side, all five runtimes) closed with that merge; this branch starts with the read side and will carry the remaining ISCs as they land.

## Landed here

### ISC-5 — a traversal surface over the action ledger

`pal cli ledger log | show <id> | stats`, filtered by `--project`, `--since`, `--until`, `--actor`, `--machine`, `--runtime`, `--outcome`, `--tool`, `--target`, `--limit`, with `--json` on every subcommand.

The write side records enough to answer questions, but only in the shape that was cheap to write — a line of JSON per action, targets held as project anchors, changes held as line deltas. Reading that back with grep gets the lines and loses the meaning: a slug is not a path, and a delta is not a diff until something replays it.

Three things the read side has to get right, each covered by a test:

- **Queries span the rotated archives**, not just the active file. Rotation exists so history survives a size cap; a reader that opened only the live file would quietly answer "what changed" with "what changed recently".
- **A project is named two ways** depending on when the entry was written — an anchor carrying the slug, or a plain absolute path from before anchoring shipped. Both resolve, or the older half of the record goes missing from every project-scoped query. On the live ledger that is 118 anchored against 6 plain.
- **Withheld, too-large and never-landed changes stay distinguishable.** All three hold no hunks, and rendering them alike would let a redacted secret read as an edit that did nothing.

`show` reports whether the recorded change is still the state of the file — in place, reverted, superseded, or gone. That is a comparison against the hashes the entry already carries, not a replay: the ledger keeps the change and not the prior file, so there is nothing to replay from unless the file happens to be sitting at its before-state again. `reverted` is exactly that case, and there the delta is run forward for real and the result reported.

New: `src/tools/ledger/query.ts`, `src/cli/ledger.ts`, `test/ledger-query.test.ts` (30 tests). Wiring in `src/cli/index.ts` and `README.md`.

## Still open, to land on this branch

| ISC | What | Blocked on |
| --- | ---- | ---------- |
| 6 | An approval gate PAL owns — today it borrows Claude Code's permission prompt, which does not survive a change of runtime and cannot express a PAL-declared rule | nothing; buildable now |
| 8 | Record edit attempts no post-tool event reports (manual denial, deny rule, a PreToolUse block) | a ruling on whether a fourth `unresolved` outcome earns its place, or the gap is better left visible |
| 10 | Ledger runtime attribution is decided by a race between config files rather than by the running agent | one probe: whether Cursor's integrated terminal exports `CURSOR_*` |
| 11 | Copilot CLI never receives the semi-static tier | a live CLI probe to choose between `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` and folding it into `additionalContext` |

## Verification

- 1600 pass / 3 skip / 0 fail across 115 files
- All 8 gates clean; klint at 0 errors and 99 warnings, unchanged by these files
- Four deliberate breaks (archive enumeration, the plain-path branch, limit direction, replay) each produced exactly one distinct red test before being restored
- Probed against the real 124-entry ledger, not only fixtures; the read-only guarantee checked by comparing file sizes and mtimes across `log` + `stats` + `show`

Co-authored by [Jarvis](https://github.com/kovrichard/portable-agent-layer)